### PR TITLE
Scala 2.10対応

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -4,21 +4,22 @@ import Keys._
 object DDDBaseBuild extends Build {
 
    //val specs2Test = "org.specs2" %% "specs2" % "1.5" % "test"
-   val scalaTest = "org.scalatest" %% "scalatest" % "1.6.1" % "test"
+   val scalaTest = "org.scalatest" %% "scalatest" % "1.9.1" % "test"
    val junit = "junit" % "junit" % "4.8.1" % "test"
-   val mockito = "org.mockito" % "mockito-core" % "1.8.5" % "test"
+   val mockito = "org.mockito" % "mockito-core" % "1.9.5" % "test"
 
    ///val = "Scala Tools Snapshots" at "http://scala-tools.org/repo-snapshots/"
 
   // NOTE: New Group ID from Scalaz 6.x and onwards
-   val scalaz = "org.scalaz" %% "scalaz-core" % "6.0.3"
+   val scalaz = "org.scalaz" %% "scalaz-core" % "6.0.4"
 
 
    lazy val commonSettings = Defaults.defaultSettings ++ Seq(
       organization := "org.sisioh",
       version := "0.0.1",
       scalaVersion := "2.9.1",
-      sbtVersion := "0.11.2",
+      crossScalaVersions := Seq("2.9.1", "2.10.0"),
+      sbtVersion := "0.12.2",
       libraryDependencies ++= Seq(junit,mockito,scalaTest,scalaz),
       scalacOptions ++= Seq("-unchecked", "-deprecation"),
       shellPrompt := { "sbt (%s)> " format projectId(_) },

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.11.2
+sbt.version=0.12.2

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,8 @@
+scalaVersion := "2.9.2"
+
 resolvers += Classpaths.typesafeResolver
 
-addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "2.0.0-RC1")
+addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "2.1.1")
 
 resolvers += "less is" at "http://repo.lessis.me"
 

--- a/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/Entity.scala
+++ b/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/Entity.scala
@@ -63,8 +63,7 @@ trait Entity[ID] {
  *
  * @author j5ik2o
  */
-@cloneable
-trait EntityCloneable[T <: Entity[ID], ID] {
+trait EntityCloneable[T <: Entity[ID], ID] extends Cloneable {
   this: Entity[ID] =>
 
   /**

--- a/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/OnMemoryRepository.scala
+++ b/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/OnMemoryRepository.scala
@@ -25,9 +25,8 @@ import Scalaz._
  *
  * @author j5ik2o
  */
-@cloneable
 class OnMemoryRepository[T <: Entity[ID] with EntityCloneable[T, ID], ID]
-  extends Repository[T, ID] with EntityIterableResolver[T, ID] {
+  extends Repository[T, ID] with EntityIterableResolver[T, ID] with Cloneable {
 
   private[core] var entities = Map.empty[Identity[ID], T]
 


### PR DESCRIPTION
Scala 2.10で使いたかったので修正してみました。
- scalaz 7にしてみたところ、 **Identityクラスがなくなっていた** ので難しいことは考えず、落ち着いてscalaz 6.0.4にしました。
- 使用しているライブラリを大体最新にしてみました。scalaz以外は特段必要はないので「これ要らないわ」ってのがあればプルリク作り直しますよー。

あとクロスコンパイル設定にしたので、sbtで

```
sbt (scala-dddbase)> +publish
```

と実行するとscala 2.9.1と2.10.0のビルドを両方行ってくれます。
