### PR TITLE
IdentityとEntityにSerializableを強制するtraitを追加。

### DIFF
--- a/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/AsyncOnMemoryRepository.scala
+++ b/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/AsyncOnMemoryRepository.scala
@@ -5,19 +5,19 @@ import scala.util._
 import ExecutionContext.Implicits.global
 import scala.util.control.NonFatal
 
-class AsyncOnMemoryRepository[ID, T <: Entity[ID] with EntityCloneable[ID, T]]
+class AsyncOnMemoryRepository[ID <: Identity[_], T <: Entity[ID] with EntityCloneable[ID, T]]
 (private val core: OnMemoryRepository[ID, T] = new OnMemoryRepository[ID, T]())
   extends AsyncRepository[ID, T] {
 
-  def resolve(identifier: Identity[ID]) = future {
+  def resolve(identifier: ID) = future {
     core.resolve(identifier).get
   }
 
-  def resolveOption(identifier: Identity[ID]) = future {
+  def resolveOption(identifier: ID) = future {
     core.resolveOption(identifier)
   }
 
-  def contains(identifier: Identity[ID]) = future {
+  def contains(identifier: ID) = future {
     core.contains(identifier).get
   }
 
@@ -25,7 +25,7 @@ class AsyncOnMemoryRepository[ID, T <: Entity[ID] with EntityCloneable[ID, T]]
     new AsyncOnMemoryRepository(core.store(entity).get)
   }
 
-  def delete(identity: Identity[ID]) = future {
+  def delete(identity: ID) = future {
     new AsyncOnMemoryRepository(core.delete(identity).get)
   }
 

--- a/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/AsyncRepository.scala
+++ b/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/AsyncRepository.scala
@@ -9,7 +9,7 @@ import scala.util.Try
  * @tparam ID 識別子の型
  * @tparam T エンティティの型
  */
-trait AsyncEntityResolver[ID, T <: Entity[ID]] {
+trait AsyncEntityResolver[ID <: Identity[_], T <: Entity[ID]] {
 
   /**
    * 識別子に該当するエンティティを取得する。
@@ -23,7 +23,7 @@ trait AsyncEntityResolver[ID, T <: Entity[ID]] {
    *          EntityNotFoundException リポジトリにアクセスできなかった場合
    *          RepositoryException リポジトリにアクセスできなかった場合
    */
-  def resolve(identity: Identity[ID]): Future[T]
+  def resolve(identity: ID): Future[T]
 
   /**
    * 識別子に該当するエンティティを取得する。
@@ -36,9 +36,9 @@ trait AsyncEntityResolver[ID, T <: Entity[ID]] {
    *         Failure:
    *          Futureが失敗した場合の例外
    */
-  def resolveOption(identity: Identity[ID]): Future[Option[T]]
+  def resolveOption(identity: ID): Future[Option[T]]
 
-  def apply(identity: Identity[ID]) = resolve(identity)
+  def apply(identity: ID) = resolve(identity)
 
   /**
    * 指定した識別子のエンティティが存在するかを返す。
@@ -51,7 +51,7 @@ trait AsyncEntityResolver[ID, T <: Entity[ID]] {
    *          RepositoryException リポジトリにアクセスできなかった場合
    *          Futureが失敗した場合の例外
    */
-  def contains(identity: Identity[ID]): Future[Boolean]
+  def contains(identity: ID): Future[Boolean]
 
   /**
    * 指定したエンティティが存在するかを返す。
@@ -74,7 +74,7 @@ trait AsyncEntityResolver[ID, T <: Entity[ID]] {
  * @tparam ID 識別子の型
  * @tparam T エンティティの型
  */
-trait AsyncRepository[ID, T <: Entity[ID]] extends AsyncEntityResolver[ID, T] {
+trait AsyncRepository[ID <: Identity[_], T <: Entity[ID]] extends AsyncEntityResolver[ID, T] {
 
   /**
    * storeメソッドの非同期版
@@ -90,7 +90,7 @@ trait AsyncRepository[ID, T <: Entity[ID]] extends AsyncEntityResolver[ID, T] {
    */
   def store(entity: T): Future[AsyncRepository[ID, T]]
 
-  def update(identifier: Identity[ID], entity: T) = store(entity)
+  def update(identifier: ID, entity: T) = store(entity)
 
   /**
    * deleteメソッドの非同期版
@@ -104,7 +104,7 @@ trait AsyncRepository[ID, T <: Entity[ID]] extends AsyncEntityResolver[ID, T] {
    *          RepositoryException リポジトリにアクセスできなかった場合
    *          Futureが失敗した場合の例外
    */
-  def delete(identity: Identity[ID]): Future[AsyncRepository[ID, T]]
+  def delete(identity: ID): Future[AsyncRepository[ID, T]]
 
   /**
    * 指定したエンティティを削除する。

--- a/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/Entity.scala
+++ b/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/Entity.scala
@@ -21,10 +21,10 @@ package org.sisioh.dddbase.core
  *
  * @author j5ik2o
  */
-trait Entity[ID] {
+trait Entity[ID <: Identity[_]] {
 
   /** エンティティの識別子。 */
-  val identity: Identity[ID]
+  val identity: ID
 
   /**
    * ハッシュコードを返す。
@@ -60,7 +60,7 @@ trait Entity[ID] {
  *
  * @author j5ik2o
  */
-trait EntityCloneable[ID, T <: Entity[ID]] extends Cloneable {
+trait EntityCloneable[ID <: Identity[_], T <: Entity[ID]] extends Cloneable {
   this: Entity[ID] =>
 
   /**
@@ -73,5 +73,11 @@ trait EntityCloneable[ID, T <: Entity[ID]] extends Cloneable {
 
 }
 
-
-
+/**
+ * シリアライズに対応したエンティティを実装するためのトレイト。
+ *
+ * @author mtgto
+ */
+trait EntitySerializable[ID <: Identity[_ <: java.io.Serializable], T <: Entity[ID]] extends Serializable {
+  this: Entity[ID] =>
+}

--- a/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/Identity.scala
+++ b/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/Identity.scala
@@ -14,4 +14,11 @@ object Identity {
 
 }
 
-
+/**
+ * シリアライズに対応したIdentityを実装するためのトレイト。
+ *
+ * @author mtgto
+ */
+trait IdentitySerializable[A] extends Identity[A] with Serializable {
+  this: Identity[A] =>
+}

--- a/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/OnMemoryRepository.scala
+++ b/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/OnMemoryRepository.scala
@@ -25,10 +25,10 @@ import scala.collection.immutable.HashMap
  *
  * @author j5ik2o
  */
-class OnMemoryRepository[ID, T <: Entity[ID] with EntityCloneable[ID, T]]
+class OnMemoryRepository[ID <: Identity[_], T <: Entity[ID] with EntityCloneable[ID, T]]
   extends Repository[ID, T] with EntityIterableResolver[ID, T] with Cloneable {
 
-  private[core] var entities = Map.empty[Identity[ID], T]
+  private[core] var entities = Map.empty[ID, T]
 
   override def equals(obj: Any) = obj match {
     case that: OnMemoryRepository[_, _] => this.entities == that.entities
@@ -44,7 +44,7 @@ class OnMemoryRepository[ID, T <: Entity[ID] with EntityCloneable[ID, T]]
     result
   }
 
-  def resolve(identifier: Identity[ID]) = synchronized {
+  override def resolve(identifier: ID) = synchronized {
     require(identifier != null)
     contains(identifier).flatMap {
       _ =>
@@ -58,16 +58,16 @@ class OnMemoryRepository[ID, T <: Entity[ID] with EntityCloneable[ID, T]]
     }
   }
 
-  def resolveOption(identifier: Identity[ID]) =
+  override def resolveOption(identifier: ID) =
     resolve(identifier).toOption
 
-  def store(entity: T): Try[OnMemoryRepository[ID, T]] = {
+  override def store(entity: T): Try[OnMemoryRepository[ID, T]] = {
     val result = clone
     result.entities += (entity.identity -> entity)
     Success(result)
   }
 
-  def delete(identifier: Identity[ID]): Try[OnMemoryRepository[ID, T]] = synchronized {
+  override def delete(identifier: ID): Try[OnMemoryRepository[ID, T]] = synchronized {
     contains(identifier).flatMap {
       e =>
         if (e == true) {

--- a/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/Repository.scala
+++ b/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/Repository.scala
@@ -24,7 +24,7 @@ import scala.util.{Success, Try}
  *
  * @author j5ik2o
  */
-trait EntityResolver[ID, T <: Entity[ID]] {
+trait EntityResolver[ID <: Identity[_], T <: Entity[ID]] {
 
   /**
    * 識別子に該当するエンティティを取得する。
@@ -36,7 +36,7 @@ trait EntityResolver[ID, T <: Entity[ID]] {
    *          EntityNotFoundExceptionは、エンティティが見つからなかった場合
    *          RepositoryExceptionは、リポジトリにアクセスできなかった場合。
    */
-  def resolve(identity: Identity[ID]): Try[T]
+  def resolve(identity: ID): Try[T]
 
   /**
    * 識別子に該当するエンティティを取得する。
@@ -44,9 +44,9 @@ trait EntityResolver[ID, T <: Entity[ID]] {
    * @param identity 識別子
    * @return Option[T]
    */
-  def resolveOption(identity: Identity[ID]): Option[T]
+  def resolveOption(identity: ID): Option[T]
 
-  def apply(identity: Identity[ID]) = resolve(identity)
+  def apply(identity: ID) = resolve(identity)
 
   /**
    * 指定した識別子のエンティティが存在するかを返す。
@@ -57,7 +57,7 @@ trait EntityResolver[ID, T <: Entity[ID]] {
    *         Failure:
    *          RepositoryExceptionは、リポジトリにアクセスできなかった場合。
    */
-  def contains(identifier: Identity[ID]): Try[Boolean]
+  def contains(identifier: ID): Try[Boolean]
 
   /**
    * 指定したのエンティティが存在するかを返す。
@@ -75,10 +75,10 @@ trait EntityResolver[ID, T <: Entity[ID]] {
 /**
  * [[scala.collection.Iterable]]
  */
-trait EntityIterableResolver[ID, T <: Entity[ID]] extends Iterable[T] {
+trait EntityIterableResolver[ID <: Identity[_], T <: Entity[ID]] extends Iterable[T] {
   this: EntityResolver[ID, T] =>
 
-  def contains(identifier: Identity[ID]): Try[Boolean] = Success(exists(_.identity == identifier))
+  def contains(identifier: ID): Try[Boolean] = Success(exists(_.identity == identifier))
 
 }
 
@@ -95,7 +95,7 @@ trait EntityIterableResolver[ID, T <: Entity[ID]] extends Iterable[T] {
  *
  * @author j5ik2o
  */
-trait Repository[ID, T <: Entity[ID]] extends EntityResolver[ID, T] {
+trait Repository[ID <: Identity[_], T <: Entity[ID]] extends EntityResolver[ID, T] {
 
   /**
    * エンティティを保存する。
@@ -108,7 +108,7 @@ trait Repository[ID, T <: Entity[ID]] extends EntityResolver[ID, T] {
    */
   def store(entity: T): Try[Repository[ID, T]]
 
-  def update(identity: Identity[ID], entity: T) = store(entity)
+  def update(identity: ID, entity: T) = store(entity)
 
   /**
    * 指定した識別子のエンティティを削除する。
@@ -119,7 +119,7 @@ trait Repository[ID, T <: Entity[ID]] extends EntityResolver[ID, T] {
    *         Failure:
    *          RepositoryExceptionは、リポジトリにアクセスできなかった場合。
    */
-  def delete(identity: Identity[ID]): Try[Repository[ID, T]]
+  def delete(identity: ID): Try[Repository[ID, T]]
 
   /**
    * 指定したエンティティを削除する。
@@ -134,7 +134,7 @@ trait Repository[ID, T <: Entity[ID]] extends EntityResolver[ID, T] {
 
 }
 
-trait CallbackEntityResolver[ID, T <: Entity[ID]] {
+trait CallbackEntityResolver[ID <: Identity[_], T <: Entity[ID]] {
   this: EntityResolver[ID, T] =>
 
   def resolve[R](callbak: T => R): R
@@ -146,7 +146,7 @@ trait CallbackEntityResolver[ID, T <: Entity[ID]] {
  *
  * @author j5ik2o
  */
-trait PagingEntityResolver[ID, T <: Entity[ID]] {
+trait PagingEntityResolver[ID <: Identity[_], T <: Entity[ID]] {
   this: EntityResolver[ID, T] =>
 
   /**

--- a/scala-dddbase-core/src/test/scala/org/sisioh/dddbase/core/AsyncOnMemoryRepositorySpec.scala
+++ b/scala-dddbase-core/src/test/scala/org/sisioh/dddbase/core/AsyncOnMemoryRepositorySpec.scala
@@ -9,12 +9,12 @@ import concurrent.duration.Duration
 
 class AsyncOnMemoryRepositorySpec extends Specification with Mockito {
 
-  class EntityImpl(val identity: Identity[UUID]) extends Entity[UUID] with EntityCloneable[UUID, EntityImpl]
+  class EntityImpl(val identity: Identity[UUID]) extends Entity[Identity[UUID]] with EntityCloneable[Identity[UUID], EntityImpl]
 
   val id = Identity(UUID.randomUUID)
 
   "The repository" should {
-    val repository = new AsyncOnMemoryRepository[UUID, EntityImpl]()
+    val repository = new AsyncOnMemoryRepository[Identity[UUID], EntityImpl]()
     "have stored entity" in {
       val entity = spy(new EntityImpl(id))
       val future = repository.store(entity).flatMap {

--- a/scala-dddbase-core/src/test/scala/org/sisioh/dddbase/core/EntityCloneableSpec.scala
+++ b/scala-dddbase-core/src/test/scala/org/sisioh/dddbase/core/EntityCloneableSpec.scala
@@ -10,7 +10,7 @@ class EntityCloneableSpec extends Specification {
   val id = Identity(UUID.randomUUID)
 
   "a cloned entity" should {
-    val entity = new Entity[UUID] with EntityCloneable[UUID, Entity[UUID]] {
+    val entity = new Entity[Identity[UUID]] with EntityCloneable[Identity[UUID], Entity[Identity[UUID]]] {
       val identity = id
     }
     "equal the entity that before clone it" in {

--- a/scala-dddbase-core/src/test/scala/org/sisioh/dddbase/core/EntitySpec.scala
+++ b/scala-dddbase-core/src/test/scala/org/sisioh/dddbase/core/EntitySpec.scala
@@ -1,14 +1,21 @@
 package org.sisioh.dddbase.core
 
+import java.io._
 import java.util.UUID
 import org.junit.runner.RunWith
 import org.specs2.mutable._
 import org.specs2.runner.JUnitRunner
 
+case class TestSerializableId(value: UUID) extends Identity[UUID] with IdentitySerializable[UUID]
+
+class TestSerializableEntity(val identity: TestSerializableId, val name: String)
+extends Entity[TestSerializableId] with EntitySerializable[TestSerializableId, TestSerializableEntity]
+
+
 @RunWith(classOf[JUnitRunner])
 class EntitySpec extends Specification {
 
-  class TestEntity(val identity: Identity[UUID]) extends Entity[UUID]
+  class TestEntity(val identity: Identity[UUID]) extends Entity[Identity[UUID]]
 
   val identity = Identity(UUID.randomUUID)
 
@@ -34,6 +41,29 @@ class EntitySpec extends Specification {
     }
     "is different when each entities have a different identity" in {
       new TestEntity(identity).hashCode must_!= new TestEntity(Identity(UUID.randomUUID)).hashCode
+    }
+  }
+
+  "not EntitySerializable entity" should {
+    "fail to seriarize entity not extends EntitySerializable" in {
+      val oos = new ObjectOutputStream(new ByteArrayOutputStream)
+      val entity = new TestEntity(identity)
+      oos.writeObject(entity) must throwA[NotSerializableException]
+    }
+  }
+
+  "EntitySerializable" should {
+    "deserialize seriarized entity if entity is serilizable" in {
+      val os = new ByteArrayOutputStream()
+      val oos = new ObjectOutputStream(os)
+      val name = "custom"
+      val id = TestSerializableId(UUID.randomUUID)
+      val entity = new TestSerializableEntity(id, name)
+      oos.writeObject(entity)
+      val ois = new ObjectInputStream(new ByteArrayInputStream(os.toByteArray))
+      val deserializedEntity: TestSerializableEntity = ois.readObject.asInstanceOf[TestSerializableEntity]
+      entity must_== deserializedEntity
+      entity.name must_== deserializedEntity.name
     }
   }
 

--- a/scala-dddbase-core/src/test/scala/org/sisioh/dddbase/core/IdentitySpec.scala
+++ b/scala-dddbase-core/src/test/scala/org/sisioh/dddbase/core/IdentitySpec.scala
@@ -1,0 +1,48 @@
+package org.sisioh.dddbase.core
+
+import java.io._
+import org.specs2.mutable._
+
+class DummyValue
+
+class DummySerializableValue extends Serializable
+
+case class NotSerializableIdentity(value: DummyValue) extends Identity[DummyValue] with IdentitySerializable[DummyValue]
+
+case class SerializableIdentity(value: Long) extends Identity[Long] with IdentitySerializable[Long]
+
+class IdentitySpec extends Specification {
+  "Identity" should {
+    "throw NotSerializableExcepption when serialization not serializable identity" in {
+      val identity = Identity(new DummyValue)
+      val oos = new ObjectOutputStream(new ByteArrayOutputStream)
+      oos.writeObject(identity) must throwA[NotSerializableException]
+    }
+
+    "deserialize serialized serializable identity" in {
+      val identity = Identity(new DummySerializableValue)
+      val os = new ByteArrayOutputStream
+      val oos = new ObjectOutputStream(os)
+      oos.writeObject(identity)
+      val ois = new ObjectInputStream(new ByteArrayInputStream(os.toByteArray))
+      val deserializedIdentity = ois.readObject
+      deserializedIdentity must beAnInstanceOf[Identity[DummySerializableValue]]
+    }
+
+    "throw NotSerializableExcepption when serialization the identity which have one or more not serializable member" in {
+      val identity = NotSerializableIdentity(new DummyValue)
+      val oos = new ObjectOutputStream(new ByteArrayOutputStream)
+      oos.writeObject(identity) must throwA[NotSerializableException]
+    }
+
+    "deserialize serialized serializable identity contains primary value" in {
+      val identity = SerializableIdentity(100L)
+      val os = new ByteArrayOutputStream
+      val oos = new ObjectOutputStream(os)
+      oos.writeObject(identity)
+      val ois = new ObjectInputStream(new ByteArrayInputStream(os.toByteArray))
+      val deserializedIdentity = ois.readObject.asInstanceOf[SerializableIdentity]
+      identity must_== deserializedIdentity
+    }
+  }
+}

--- a/scala-dddbase-core/src/test/scala/org/sisioh/dddbase/core/OnMemoryRepositorySpec.scala
+++ b/scala-dddbase-core/src/test/scala/org/sisioh/dddbase/core/OnMemoryRepositorySpec.scala
@@ -10,12 +10,12 @@ import scala.util.Success
 @RunWith(classOf[JUnitRunner])
 class OnMemoryRepositorySpec extends Specification with Mockito {
 
-  class EntityImpl(val identity: Identity[UUID]) extends Entity[UUID] with EntityCloneable[UUID, EntityImpl]
+  class EntityImpl(val identity: Identity[UUID]) extends Entity[Identity[UUID]] with EntityCloneable[Identity[UUID], EntityImpl]
 
   val id = Identity(UUID.randomUUID())
 
   "The repository" should {
-    val repository = new OnMemoryRepository[UUID, EntityImpl]()
+    val repository = new OnMemoryRepository[Identity[UUID], EntityImpl]()
     "have stored entity" in {
       val entity = spy(new EntityImpl(id))
       val repos = repository.store(entity)
@@ -45,7 +45,7 @@ class OnMemoryRepositorySpec extends Specification with Mockito {
   }
 
   "The cloned repository" should {
-    val repository = new OnMemoryRepository[UUID, EntityImpl]()
+    val repository = new OnMemoryRepository[Identity[UUID], EntityImpl]()
     "equals the repository before clone" in {
       repository must_== repository.clone
     }


### PR DESCRIPTION
## 【やりたいこと】

・Identityを継承した独自のIDクラスも作りたかったのです。
UserエンティティにはIdentity[Long]ではなくてcase class UserId(value: Long): Identity[Long]を使ってあげたくなったのです。

・EntitySerializable（Serializable + IDがSerializableであるtrait）を作りたかったのです。
キャッシュするときにidentifierに@transientつけまくる作業はもうやりたくなかったのです。

そのために、現状のEntityの定義では難しかったので書き直してみましたが、今までのものと比べて直したほうが所があると思うんで、まずはたたき台のつもりでPRしました。
## 【やってみたこと】

一番変えたかったのはEntityの定義です。
https://github.com/mtgto/scala-dddbase/blob/6734f10f610e9c1420fcaf119a95cae56a77b06a/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/Entity.scala

既存のEntityの定義は

``` scala
trait Entity[ID]
```

ですが、これではEntityのIdentityを継承したIDを渡せないので、

``` scala
trait Entity[ID <: Identity[_]]
```

に変更しました。
## 【つかいかた】

使い方としては、

``` scala
case class UserId(value: Long) extends Identity[Long] with IdentitySerializable[Long]
case class User(identity: UserId) extends Entity[UserId] with EntitySerializable[UserId]
```

これでUser（とUserId）がSerializableになることをコンパイル時に保証出来ます。
（Id以外のEntityのメンバがSerializableを実装してないとNotSerializableExceptionが発生します）
## 【それ以外】

IdentitySerializable（とそのテスト）とEntitySerializable（とそのテスト）を書きました。
