### PR TITLE
型引数の削減

### DIFF
--- a/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/EntityWriter.scala
+++ b/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/EntityWriter.scala
@@ -27,8 +27,10 @@ import org.sisioh.dddbase.core.model.{Entity, Identity}
  * @tparam T エンティティの型
  * @tparam M モナド
  */
-trait EntityWriter[+R <: EntityWriter[_, ID, T, M], ID <: Identity[_], T <: Entity[ID], M[+A]]
+trait EntityWriter[ID <: Identity[_], T <: Entity[ID], M[+A]]
   extends EntityIO {
+
+  type R <: EntityWriter[ID, T, M]
 
   /**
    * エンティティを保存する。

--- a/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/Repository.scala
+++ b/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/Repository.scala
@@ -26,11 +26,14 @@ import scala.language.higherKinds
  * Immutableなリポジトリは新しいリポジトリインスタンスを返し、
  * Mutableなリポジトリは同一インスタンスを返すこと、を推奨する。
  *
- * @tparam R リポジトリの型
  * @tparam ID エンティティの識別子の型
  * @tparam T エンティティの型
  * @tparam M モナドの型
  */
-trait Repository[+R <: Repository[_, ID, T, M], ID <: Identity[_], T <: Entity[ID], M[+A]]
-  extends EntityReader[ID, T, M] with EntityWriter[R, ID, T, M]
+trait Repository[ID <: Identity[_], T <: Entity[ID], M[+A]]
+  extends EntityReader[ID, T, M] with EntityWriter[ID, T, M] {
+
+  type R <: Repository[ID, T, M]
+
+}
 

--- a/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/async/AsyncEntityWriter.scala
+++ b/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/async/AsyncEntityWriter.scala
@@ -1,46 +1,48 @@
 package org.sisioh.dddbase.core.lifecycle.async
 
+import org.sisioh.dddbase.core.lifecycle.{EntityWriter, RepositoryWithEntity}
 import org.sisioh.dddbase.core.model.{Entity, Identity}
 import scala.concurrent.{ExecutionContext, Future}
-import org.sisioh.dddbase.core.lifecycle.{EntityWriter, RepositoryWithEntity}
 
 /**
-  * 非同期版[[org.sisioh.dddbase.core.lifecycle.EntityWriter]]。
-  *
-  * @see [[org.sisioh.dddbase.core.lifecycle.EntityWriter]]
-  *
-  * @tparam ID 識別子の型
-  * @tparam T エンティティの型
-  */
-trait AsyncEntityWriter[+R <: AsyncEntityWriter[_, ID, T], ID <: Identity[_], T <: Entity[ID]]
-  extends EntityWriter[R, ID, T, Future] {
+ * 非同期版[[org.sisioh.dddbase.core.lifecycle.EntityWriter]]。
+ *
+ * @see [[org.sisioh.dddbase.core.lifecycle.EntityWriter]]
+ *
+ * @tparam ID 識別子の型
+ * @tparam T エンティティの型
+ */
+trait AsyncEntityWriter[ID <: Identity[_], T <: Entity[ID]]
+  extends EntityWriter[ID, T, Future] {
 
-     implicit val executor: ExecutionContext
+  implicit val executor: ExecutionContext
 
-     /**
-      * エンティティを保存する。
-      *
-      * @see [[org.sisioh.dddbase.core.lifecycle.Repository]] `store`
-      *
-      * @param entity 保存する対象のエンティティ
-      * @return Success:
-      *         非同期リポジトリ
-      *         Failure:
-      *         RepositoryException リポジトリにアクセスできなかった場合
-      *         Futureが失敗した場合の例外
-      */
-     def store(entity: T): Future[RepositoryWithEntity[R, T]]
+  type R <: AsyncEntityWriter[ID, T]
 
-     /**
-      * 識別子を指定してエンティティを削除する。
-      *
-      * @param identity 識別子
-      * @return Success:
-      *         非同期リポジトリ
-      *         Failure:
-      *         RepositoryException リポジトリにアクセスできなかった場合
-      *         Futureが失敗した場合の例外
-      */
-     def delete(identity: ID): Future[R]
+  /**
+   * エンティティを保存する。
+   *
+   * @see [[org.sisioh.dddbase.core.lifecycle.Repository]] `store`
+   *
+   * @param entity 保存する対象のエンティティ
+   * @return Success:
+   *         非同期リポジトリ
+   *         Failure:
+   *         RepositoryException リポジトリにアクセスできなかった場合
+   *         Futureが失敗した場合の例外
+   */
+  def store(entity: T): Future[RepositoryWithEntity[R, T]]
 
-   }
+  /**
+   * 識別子を指定してエンティティを削除する。
+   *
+   * @param identity 識別子
+   * @return Success:
+   *         非同期リポジトリ
+   *         Failure:
+   *         RepositoryException リポジトリにアクセスできなかった場合
+   *         Futureが失敗した場合の例外
+   */
+  def delete(identity: ID): Future[R]
+
+}

--- a/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/async/AsyncRepository.scala
+++ b/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/async/AsyncRepository.scala
@@ -16,9 +16,9 @@
  */
 package org.sisioh.dddbase.core.lifecycle.async
 
-import scala.concurrent._
-import org.sisioh.dddbase.core.model.{Identity, Entity}
 import org.sisioh.dddbase.core.lifecycle.Repository
+import org.sisioh.dddbase.core.model.{Identity, Entity}
+import scala.concurrent._
 
 /**
  * 非同期版[[org.sisioh.dddbase.core.lifecycle.Repository]]。
@@ -28,10 +28,14 @@ import org.sisioh.dddbase.core.lifecycle.Repository
  * @tparam ID 識別子の型
  * @tparam T エンティティの型
  */
-trait AsyncRepository[+R <: AsyncRepository[_, ID, T], ID <: Identity[_], T <: Entity[ID]]
-  extends Repository[R, ID, T, Future]
+trait AsyncRepository[ID <: Identity[_], T <: Entity[ID]]
+  extends Repository[ID, T, Future]
   with AsyncEntityReader[ID, T]
-  with AsyncEntityWriter[R, ID, T]
+  with AsyncEntityWriter[ID, T] {
+
+  type R <: AsyncRepository[ID, T]
+
+}
 
 
 

--- a/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/forwarding/async/ForwardingAsyncRepository.scala
+++ b/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/forwarding/async/ForwardingAsyncRepository.scala
@@ -1,16 +1,18 @@
 package org.sisioh.dddbase.core.lifecycle.forwarding.async
 
-import org.sisioh.dddbase.core.model.{Entity, Identity}
 import org.sisioh.dddbase.core.lifecycle.async.{AsyncEntityWriter, AsyncEntityReader, AsyncRepository}
+import org.sisioh.dddbase.core.model.{Entity, Identity}
 
-trait ForwardingAsyncRepository[R <: AsyncRepository[_, ID, T], ID <: Identity[_], T <: Entity[ID]]
+trait ForwardingAsyncRepository[ID <: Identity[_], T <: Entity[ID]]
   extends ForwardingAsyncEntityReader[ID, T]
-  with ForwardingAsyncEntityWriter[R, ID, T]
-  with AsyncRepository[R, ID, T]{
+  with ForwardingAsyncEntityWriter[ID, T]
+  with AsyncRepository[ID, T] {
 
-  protected val delegateAsyncRepository: AsyncRepository[_, ID, T]
+  type R <: ForwardingAsyncRepository[ID, T]
+
+  protected val delegateAsyncRepository: AsyncRepository[ID, T]
   protected val delegateAsyncEntityReader: AsyncEntityReader[ID, T] = delegateAsyncRepository
-  protected val delegateAsyncEntityWriter: AsyncEntityWriter[_, ID, T] = delegateAsyncRepository
+  protected val delegateAsyncEntityWriter: AsyncEntityWriter[ID, T] = delegateAsyncRepository
 
 }
 

--- a/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/forwarding/sync/ForwardingSyncEntityWriter.scala
+++ b/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/forwarding/sync/ForwardingSyncEntityWriter.scala
@@ -1,16 +1,18 @@
 package org.sisioh.dddbase.core.lifecycle.forwarding.sync
 
 import org.sisioh.dddbase.core.lifecycle.RepositoryWithEntity
+import org.sisioh.dddbase.core.lifecycle.sync.SyncEntityWriter
 import org.sisioh.dddbase.core.model.{Entity, Identity}
 import scala.util.Try
-import org.sisioh.dddbase.core.lifecycle.sync.SyncEntityWriter
 
-trait ForwardingSyncEntityWriter[+R <: SyncEntityWriter[_, ID, T], ID <: Identity[_], T <: Entity[ID]]
-  extends SyncEntityWriter[R, ID, T] {
+trait ForwardingSyncEntityWriter[ID <: Identity[_], T <: Entity[ID]]
+  extends SyncEntityWriter[ID, T] {
 
-  protected val delegateEntityWriter: SyncEntityWriter[_, ID, T]
+  type R <: ForwardingSyncEntityWriter[ID, T]
 
-  protected def createInstance(state: Try[(SyncEntityWriter[_, ID, T], Option[T])]): Try[(R, Option[T])]
+  protected val delegateEntityWriter: SyncEntityWriter[ID, T]
+
+  protected def createInstance(state: Try[(R, Option[T])]): Try[(R, Option[T])]
 
   def store(entity: T): Try[RepositoryWithEntity[R, T]] = {
     createInstance(

--- a/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/forwarding/sync/ForwardingSyncRepository.scala
+++ b/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/forwarding/sync/ForwardingSyncRepository.scala
@@ -1,15 +1,17 @@
 package org.sisioh.dddbase.core.lifecycle.forwarding.sync
 
-import org.sisioh.dddbase.core.model.{Entity, Identity}
 import org.sisioh.dddbase.core.lifecycle.sync.{SyncEntityWriter, SyncEntityReader, SyncRepository}
+import org.sisioh.dddbase.core.model.{Entity, Identity}
 
-trait ForwardingSyncRepository[+R <: SyncRepository[_, ID, T], ID <: Identity[_], T <: Entity[ID]]
+trait ForwardingSyncRepository[ID <: Identity[_], T <: Entity[ID]]
   extends ForwardingSyncEntityReader[ID, T]
-  with ForwardingSyncEntityWriter[R, ID, T]
-  with SyncRepository[R, ID, T] {
+  with ForwardingSyncEntityWriter[ID, T]
+  with SyncRepository[ID, T] {
 
-  protected val delegateRepository: SyncRepository[_, ID, T]
+  type R <: ForwardingSyncRepository[ID, T]
+
+  protected val delegateRepository: SyncRepository[ID, T]
   protected val delegateEntityReader: SyncEntityReader[ID, T] = delegateRepository
-  protected val delegateEntityWriter: SyncEntityWriter[_, ID, T] = delegateRepository
+  protected val delegateEntityWriter: SyncEntityWriter[ID, T] = delegateRepository
 
 }

--- a/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/memory/async/AsyncRepositoryOnMemory.scala
+++ b/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/memory/async/AsyncRepositoryOnMemory.scala
@@ -22,12 +22,14 @@ import org.sisioh.dddbase.core.model.{Identity, EntityCloneable, Entity}
 /**
  * オンメモリで動作する[[org.sisioh.dddbase.core.lifecycle.async.AsyncRepository]]。
  *
- * @tparam AR 当該リポジトリを実装する派生型
  * @tparam ID 識別子の型
  * @tparam T エンティティの型
  */
 trait AsyncRepositoryOnMemory
-[+AR <: AsyncRepository[_, ID, T],
-ID <: Identity[_],
+[ID <: Identity[_],
 T <: Entity[ID] with EntityCloneable[ID, T]]
-  extends AsyncRepository[AR, ID, T]
+  extends AsyncRepository[ID, T] {
+
+  type R <: AsyncRepositoryOnMemory[ID, T]
+
+}

--- a/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/memory/async/AsyncRepositoryOnMemorySupportByChunk.scala
+++ b/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/memory/async/AsyncRepositoryOnMemorySupportByChunk.scala
@@ -11,17 +11,15 @@ import org.sisioh.dddbase.core.lifecycle.memory.sync.SyncRepositoryOnMemory
  * [[org.sisioh.dddbase.core.lifecycle.memory.async.AsyncRepositoryOnMemorySupport]]に
  * [[org.sisioh.dddbase.core.lifecycle.EntitiesChunk]]のための機能を追加するトレイト。
  *
- * @tparam AR 当該リポジトリを実装する派生型
  * @tparam SR 内部で利用する同期型リポジトリの型
  * @tparam ID 識別子の型
  * @tparam T エンティティの型
  */
 trait AsyncRepositoryOnMemorySupportByChunk
-[+AR <: AsyncRepository[_, ID, T],
-SR <: SyncRepositoryOnMemory[_, ID, T] with SyncEntityReaderByChunk[ID, T],
+[SR <: SyncRepositoryOnMemory[ID, T] with SyncEntityReaderByChunk[ID, T],
 ID <: Identity[_],
 T <: Entity[ID] with EntityCloneable[ID, T]]
-  extends AsyncRepositoryOnMemorySupport[AR, SR, ID, T]
+  extends AsyncRepositoryOnMemorySupport[SR, ID, T]
   with AsyncEntityReaderByChunk[ID, T] {
 
   def resolveChunk(index: Int, maxEntities: Int)(implicit executor: ExecutionContext): Future[EntitiesChunk[ID, T]] = future {

--- a/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/memory/async/AsyncRepositoryOnMemorySupportByOption.scala
+++ b/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/memory/async/AsyncRepositoryOnMemorySupportByOption.scala
@@ -9,17 +9,15 @@ import org.sisioh.dddbase.core.lifecycle.memory.sync.SyncRepositoryOnMemory
 /**
  * [org.sisioh.dddbase.core.lifecycle.memory.async.syncOnMemoryRepositorySupport]]にOption型のサポートを追加するトレイト。
  *
- * @tparam AR 当該リポジトリを実装する派生型
  * @tparam SR 内部で利用する同期型リポジトリの型
  * @tparam ID 識別子の型
  * @tparam T エンティティの型
  */
 trait AsyncRepositoryOnMemorySupportByOption
-[+AR <: AsyncRepository[_, ID, T],
-SR <: SyncRepositoryOnMemory[_, ID, T] with SyncEntityReaderByOption[ID, T],
+[SR <: SyncRepositoryOnMemory[ID, T] with SyncEntityReaderByOption[ID, T],
 ID <: Identity[_],
 T <: Entity[ID] with EntityCloneable[ID, T]]
-  extends AsyncRepositoryOnMemorySupport[AR, SR, ID, T]
+  extends AsyncRepositoryOnMemorySupport[SR, ID, T]
   with AsyncEntityReaderByOption[ID, T] {
 
   def resolveOption(identifier: ID)(implicit executor: ExecutionContext) = future {

--- a/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/memory/async/AsyncRepositoryOnMemorySupportByPredicate.scala
+++ b/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/memory/async/AsyncRepositoryOnMemorySupportByPredicate.scala
@@ -11,17 +11,15 @@ import org.sisioh.dddbase.core.lifecycle.memory.sync.SyncRepositoryOnMemory
  * [[org.sisioh.dddbase.core.lifecycle.memory.async.AsyncRepositoryOnMemorySupport]]に
  * [[org.sisioh.dddbase.core.lifecycle.async.AsyncEntityReaderByPredicate]]ための機能を追加するトレイト。
  *
- * @tparam AR 当該リポジトリを実装する派生型
  * @tparam SR 内部で利用する同期型リポジトリの型
  * @tparam ID 識別子の型
  * @tparam T エンティティの型
  */
 trait AsyncRepositoryOnMemorySupportByPredicate
-[+AR <: AsyncRepository[_, ID, T],
-SR <: SyncRepositoryOnMemory[_, ID, T] with SyncEntityReaderByPredicate[ID, T],
+[SR <: SyncRepositoryOnMemory[ID, T] with SyncEntityReaderByPredicate[ID, T],
 ID <: Identity[_],
 T <: Entity[ID] with EntityCloneable[ID, T]]
-  extends AsyncRepositoryOnMemorySupport[AR, SR, ID, T]
+  extends AsyncRepositoryOnMemorySupport[SR, ID, T]
   with AsyncEntityReaderByPredicate[ID, T] {
 
   def filterByPredicate

--- a/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/memory/async/AsyncRepositoryOnMemorySupportBySeq.scala
+++ b/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/memory/async/AsyncRepositoryOnMemorySupportBySeq.scala
@@ -9,17 +9,15 @@ import org.sisioh.dddbase.core.lifecycle.memory.sync.SyncRepositoryOnMemory
 /**
  * [[org.sisioh.dddbase.core.lifecycle.memory.async.AsyncRepositoryOnMemorySupport]]に全件取得のための機能を追加するトレイト。
  *
- * @tparam AR 当該リポジトリを実装する派生型
  * @tparam SR 内部で利用する同期型リポジトリの型
  * @tparam ID 識別子の型
  * @tparam T エンティティの型
  */
 trait AsyncRepositoryOnMemorySupportBySeq
-[+AR <: AsyncRepository[_, ID, T],
-SR <: SyncRepositoryOnMemory[_, ID, T] with SyncEntityReaderByOption[ID, T],
+[SR <: SyncRepositoryOnMemory[ID, T] with SyncEntityReaderByOption[ID, T],
 ID <: Identity[_],
 T <: Entity[ID] with EntityCloneable[ID, T]]
-  extends AsyncRepositoryOnMemorySupport[AR, SR, ID, T] with AsyncEntityReaderBySeq[ID, T] {
+  extends AsyncRepositoryOnMemorySupport[SR, ID, T] with AsyncEntityReaderBySeq[ID, T] {
 
   def resolveAll(implicit executor: ExecutionContext): Future[Seq[T]] = future {
     core.toSeq.map(_.asInstanceOf[T])

--- a/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/memory/async/GenericAsyncRepositoryOnMemory.scala
+++ b/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/memory/async/GenericAsyncRepositoryOnMemory.scala
@@ -30,7 +30,9 @@ import scala.concurrent.ExecutionContext
 class GenericAsyncRepositoryOnMemory[ID <: Identity[_], T <: Entity[ID] with EntityCloneable[ID, T] with Ordered[T]]
 (protected val core: GenericSyncRepositoryOnMemory[ID, T] = GenericSyncRepositoryOnMemory[ID, T]())
 (implicit val executor: ExecutionContext)
-  extends AsyncRepositoryOnMemorySupport[GenericAsyncRepositoryOnMemory[ID, T], GenericSyncRepositoryOnMemory[ID, T], ID, T] {
+  extends AsyncRepositoryOnMemorySupport[GenericSyncRepositoryOnMemory[ID, T], ID, T] {
+
+  type R = GenericAsyncRepositoryOnMemory[ID, T]
 
   protected def createInstance(state: (GenericSyncRepositoryOnMemory[ID, T], Option[T])): (GenericAsyncRepositoryOnMemory[ID, T], Option[T]) =
     (new GenericAsyncRepositoryOnMemory[ID, T](state._1), state._2)

--- a/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/memory/mutable/async/AsyncRepositoryOnMemory.scala
+++ b/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/memory/mutable/async/AsyncRepositoryOnMemory.scala
@@ -16,27 +16,24 @@
  */
 package org.sisioh.dddbase.core.lifecycle.memory.mutable.async
 
-import org.sisioh.dddbase.core.lifecycle.async.AsyncRepository
 import org.sisioh.dddbase.core.lifecycle.memory.async.AsyncRepositoryOnMemorySupport
-import org.sisioh.dddbase.core.model.{Identity, EntityCloneable, Entity}
 import org.sisioh.dddbase.core.lifecycle.memory.sync.SyncRepositoryOnMemory
+import org.sisioh.dddbase.core.model.{Identity, EntityCloneable, Entity}
 
 /**
  * 非同期型オンメモリ可変リポジトリのためのトレイト。
  *
- * @tparam AR 当該リポジトリを実装する派生型
  * @tparam SR 内部で利用する同期型リポジトリの型
  * @tparam ID 識別子の型
  * @tparam T エンティティの型
  */
 trait AsyncRepositoryOnMemory
-[+AR <: AsyncRepository[_, ID, T],
-SR <: SyncRepositoryOnMemory[_, ID, T],
+[SR <: SyncRepositoryOnMemory[ID, T],
 ID <: Identity[_],
 T <: Entity[ID] with EntityCloneable[ID, T] with Ordered[T]]
-  extends AsyncRepositoryOnMemorySupport[AR, SR, ID, T] {
+  extends AsyncRepositoryOnMemorySupport[SR, ID, T] {
 
-  protected def createInstance(state: (SR, Option[T])): (AR, Option[T]) =
-    (this.asInstanceOf[AR], state._2)
+  protected def createInstance(state: (SR, Option[T])): (R, Option[T]) =
+    (this.asInstanceOf[R], state._2)
 
 }

--- a/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/memory/mutable/async/GenericAsyncRepositoryOnMemory.scala
+++ b/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/memory/mutable/async/GenericAsyncRepositoryOnMemory.scala
@@ -30,7 +30,10 @@ import scala.concurrent.ExecutionContext
 class GenericAsyncRepositoryOnMemory[ID <: Identity[_], T <: Entity[ID] with EntityCloneable[ID, T] with Ordered[T]]
 (protected val core: GenericSyncRepositoryOnMemory[ID, T] = GenericSyncRepositoryOnMemory[ID, T]())
 (implicit val executor: ExecutionContext)
-  extends AsyncRepositoryOnMemory[GenericAsyncRepositoryOnMemory[ID, T], GenericSyncRepositoryOnMemory[ID, T], ID, T] {
+  extends AsyncRepositoryOnMemory[GenericSyncRepositoryOnMemory[ID, T], ID, T] {
+
+  type R = GenericAsyncRepositoryOnMemory[ID, T]
+
 }
 
 /**

--- a/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/memory/mutable/sync/GenericSyncRepositoryOnMemory.scala
+++ b/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/memory/mutable/sync/GenericSyncRepositoryOnMemory.scala
@@ -25,7 +25,11 @@ import org.sisioh.dddbase.core.model.{Identity, EntityCloneable, Entity}
  * @tparam T エンティティの型
  */
 class GenericSyncRepositoryOnMemory[ID <: Identity[_], T <: Entity[ID] with EntityCloneable[ID, T] with Ordered[T]]
-  extends SyncRepositoryOnMemorySupport[GenericSyncRepositoryOnMemory[ID, T], ID, T]
+  extends SyncRepositoryOnMemorySupport[ID, T] {
+
+  override type R = GenericSyncRepositoryOnMemory[ID, T]
+
+}
 
 /**
  * コンパニオンオブジェクト。

--- a/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/memory/mutable/sync/SyncRepositoryOnMemorySupport.scala
+++ b/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/memory/mutable/sync/SyncRepositoryOnMemorySupport.scala
@@ -26,24 +26,22 @@ import org.sisioh.dddbase.core.lifecycle.memory.sync.SyncRepositoryOnMemory
 /**
  * オンメモリで動作する可変リポジトリの実装。
  *
- * @tparam R 当該リポジトリを実装する派生型
  * @tparam ID エンティティの識別子の型
  * @tparam T エンティティの型
  */
 trait SyncRepositoryOnMemorySupport
-[+R <: SyncRepository[_, ID, T],
-ID <: Identity[_],
+[ID <: Identity[_],
 T <: Entity[ID] with EntityCloneable[ID, T] with Ordered[T]]
-  extends SyncRepositoryOnMemory[R, ID, T] {
+  extends SyncRepositoryOnMemory[ID, T] {
 
   /**
    * 内部で利用されるオンメモリリポジトリ
    */
-  protected var core: SyncRepositoryOnMemory[_, ID, T] =
+  protected var core: SyncRepositoryOnMemory[ID, T] =
     new org.sisioh.dddbase.core.lifecycle.memory.sync.GenericSyncRepositoryOnMemory[ID, T]()
 
   override def equals(obj: Any) = obj match {
-    case that: SyncRepositoryOnMemorySupport[_, _, _] =>
+    case that: SyncRepositoryOnMemorySupport[_, _] =>
       this.core == that.core
     case _ => false
   }
@@ -53,7 +51,7 @@ T <: Entity[ID] with EntityCloneable[ID, T] with Ordered[T]]
   def store(entity: T): Try[RepositoryWithEntity[R, T]] = {
     core.store(entity).map {
       result =>
-        core = result.repository.asInstanceOf[SyncRepositoryOnMemory[_, ID, T]]
+        core = result.repository.asInstanceOf[SyncRepositoryOnMemory[ID, T]]
         RepositoryWithEntity(this.asInstanceOf[R], result.entity)
     }
   }
@@ -61,7 +59,7 @@ T <: Entity[ID] with EntityCloneable[ID, T] with Ordered[T]]
   def delete(identity: ID): Try[R] = {
     core.delete(identity).map {
       result =>
-        core = result.asInstanceOf[SyncRepositoryOnMemory[_, ID, T]]
+        core = result.asInstanceOf[SyncRepositoryOnMemory[ID, T]]
         this.asInstanceOf[R]
     }
   }

--- a/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/memory/mutable/sync/SyncRepositoryOnMemorySupportByChunk.scala
+++ b/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/memory/mutable/sync/SyncRepositoryOnMemorySupportByChunk.scala
@@ -9,15 +9,13 @@ import scala.util._
  * [[org.sisioh.dddbase.core.lifecycle.memory.mutable.sync.SyncRepositoryOnMemorySupport]]に
  * [[org.sisioh.dddbase.core.lifecycle.EntitiesChunk]]ための機能を追加するトレイト。
  *
- * @tparam R 当該リポジトリを実装する派生型
  * @tparam ID エンティティの識別子の型
  * @tparam T エンティティの型
  */
 trait SyncRepositoryOnMemorySupportByChunk
-[+R <: SyncRepository[_, ID, T],
-ID <: Identity[_],
+[ID <: Identity[_],
 T <: Entity[ID] with EntityCloneable[ID, T] with Ordered[T]]
-  extends SyncRepositoryOnMemorySupport[R, ID, T] with SyncEntityReaderByChunk[ID, T] {
+  extends SyncRepositoryOnMemorySupport[ID, T] with SyncEntityReaderByChunk[ID, T] {
 
   def resolveChunk(index: Int, maxEntities: Int): Try[EntitiesChunk[ID, T]] = {
     val subEntities = toList.slice(index * maxEntities, index * maxEntities + maxEntities)

--- a/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/memory/mutable/sync/SyncRepositoryOnMemorySupportByOption.scala
+++ b/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/memory/mutable/sync/SyncRepositoryOnMemorySupportByOption.scala
@@ -8,15 +8,13 @@ import scala.util._
 /**
  * [[org.sisioh.dddbase.core.lifecycle.memory.mutable.sync.SyncRepositoryOnMemorySupport]]にOption型のサポートを追加するトレイト。
  *
- * @tparam R 当該リポジトリを実装する派生型
  * @tparam ID エンティティの識別子の型
  * @tparam T エンティティの型
  */
 trait SyncRepositoryOnMemorySupportByOption
-[+R <: SyncRepository[_, ID, T],
-ID <: Identity[_],
+[ID <: Identity[_],
 T <: Entity[ID] with EntityCloneable[ID, T] with Ordered[T]]
-  extends SyncRepositoryOnMemorySupport[R, ID, T]
+  extends SyncRepositoryOnMemorySupport[ID, T]
   with SyncEntityReaderByOption[ID, T] {
 
   def resolveOption(identity: ID): Try[Option[T]] = synchronized {

--- a/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/memory/mutable/sync/SyncRepositoryOnMemorySupportByPredicate.scala
+++ b/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/memory/mutable/sync/SyncRepositoryOnMemorySupportByPredicate.scala
@@ -9,15 +9,13 @@ import scala.util._
  * [[org.sisioh.dddbase.core.lifecycle.memory.mutable.sync.SyncRepositoryOnMemorySupport]]に
  * [[org.sisioh.dddbase.core.lifecycle.sync.SyncEntityReaderByPredicate]]ための機能を追加するトレイト。
  *
- * @tparam R 当該リポジトリを実装する派生型
  * @tparam ID エンティティの識別子の型
  * @tparam T エンティティの型
  */
 trait SyncRepositoryOnMemorySupportByPredicate
-[+R <: SyncRepository[_, ID, T],
-ID <: Identity[_],
+[ID <: Identity[_],
 T <: Entity[ID] with EntityCloneable[ID, T] with Ordered[T]]
-  extends SyncRepositoryOnMemorySupport[R, ID, T]
+  extends SyncRepositoryOnMemorySupport[ID, T]
   with SyncEntityReaderByPredicate[ID, T] {
 
   def filterByPredicate

--- a/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/memory/sync/GenericSyncRepositoryOnMemory.scala
+++ b/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/memory/sync/GenericSyncRepositoryOnMemory.scala
@@ -17,7 +17,6 @@
 package org.sisioh.dddbase.core.lifecycle.memory.sync
 
 import org.sisioh.dddbase.core.model.{Identity, EntityCloneable, Entity}
-import org.sisioh.dddbase.core.lifecycle.memory.sync
 
 /**
  * 汎用的な非同期型オンメモリ不変リポジトリ。
@@ -26,7 +25,11 @@ import org.sisioh.dddbase.core.lifecycle.memory.sync
  * @tparam T エンティティの型
  */
 class GenericSyncRepositoryOnMemory[ID <: Identity[_], T <: Entity[ID] with EntityCloneable[ID, T] with Ordered[T]]
-  extends SyncRepositoryOnMemorySupport[GenericSyncRepositoryOnMemory[ID, T], ID, T]
+  extends SyncRepositoryOnMemorySupport[ID, T] {
+
+  override type R = GenericSyncRepositoryOnMemory[ID, T]
+
+}
 
 /**
  * コンパニオンオブジェクト。

--- a/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/memory/sync/SyncRepositoryOnMemory.scala
+++ b/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/memory/sync/SyncRepositoryOnMemory.scala
@@ -21,12 +21,15 @@ import org.sisioh.dddbase.core.model.{Identity, EntityCloneable, Entity}
 /**
  * オンメモリリポジトリを表すトレイト。
  *
- * @tparam R 当該リポジトリを実装する派生型
  * @tparam ID エンティティの識別子の型
  * @tparam T エンティティの型
  */
 trait SyncRepositoryOnMemory
-[+R <: SyncRepository[_, ID, T], ID <: Identity[_], T <: Entity[ID] with EntityCloneable[ID, T]]
-  extends SyncRepository[R, ID, T] with SyncEntityReaderByIterable[ID, T] with Cloneable
+[ID <: Identity[_], T <: Entity[ID] with EntityCloneable[ID, T]]
+  extends SyncRepository[ID, T] with SyncEntityReaderByIterable[ID, T] with Cloneable {
+
+  type R <: SyncRepositoryOnMemory[ID, T]
+
+}
 
 

--- a/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/memory/sync/SyncRepositoryOnMemorySupport.scala
+++ b/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/memory/sync/SyncRepositoryOnMemorySupport.scala
@@ -28,15 +28,13 @@ import scala.util.Try
 /**
  * オンメモリで動作する不変リポジトリの実装。
  *
- * @tparam R 当該リポジトリを実装する派生型
  * @tparam ID エンティティの識別子の型
  * @tparam T エンティティの型
  */
 trait SyncRepositoryOnMemorySupport
-[+R <: SyncRepository[_, ID, T],
-ID <: Identity[_],
+[ID <: Identity[_],
 T <: Entity[ID] with EntityCloneable[ID, T] with Ordered[T]]
-  extends SyncRepositoryOnMemory[R, ID, T] {
+  extends SyncRepositoryOnMemory[ID, T] {
 
   /**
    * エンティティを保存するためのマップ。
@@ -44,7 +42,7 @@ T <: Entity[ID] with EntityCloneable[ID, T] with Ordered[T]]
   protected[core] var entities = new HashMap[ID, T]()
 
   override def equals(obj: Any) = obj match {
-    case that: SyncRepositoryOnMemorySupport[_, _, _] =>
+    case that: SyncRepositoryOnMemorySupport[_, _] =>
       this.entities == that.entities
     case _ => false
   }
@@ -52,7 +50,7 @@ T <: Entity[ID] with EntityCloneable[ID, T] with Ordered[T]]
   override def hashCode = 31 * entities.hashCode()
 
   override def clone: R = synchronized {
-    val result = super.clone.asInstanceOf[SyncRepositoryOnMemorySupport[R, ID, T]]
+    val result = super.clone.asInstanceOf[SyncRepositoryOnMemorySupport[ID, T]]
     val array = result.entities.toArray
     result.entities = HashMap(array: _*).map(e => e._1 -> e._2.clone)
     result.asInstanceOf[R]
@@ -72,7 +70,7 @@ T <: Entity[ID] with EntityCloneable[ID, T] with Ordered[T]]
 
 
   override def store(entity: T): Try[RepositoryWithEntity[R, T]] = synchronized {
-    val result = clone.asInstanceOf[SyncRepositoryOnMemorySupport[R, ID, T]]
+    val result = clone.asInstanceOf[SyncRepositoryOnMemorySupport[ID, T]]
     result.entities += (entity.identity -> entity)
     Success(RepositoryWithEntity(result.asInstanceOf[R], entity))
   }
@@ -81,7 +79,7 @@ T <: Entity[ID] with EntityCloneable[ID, T] with Ordered[T]]
     contains(identifier).flatMap {
       e =>
         if (e) {
-          val result = clone.asInstanceOf[SyncRepositoryOnMemorySupport[R, ID, T]]
+          val result = clone.asInstanceOf[SyncRepositoryOnMemorySupport[ID, T]]
           result.entities -= identifier
           Success(result.asInstanceOf[R])
         } else {

--- a/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/memory/sync/SyncRepositoryOnMemorySupportByChunk.scala
+++ b/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/memory/sync/SyncRepositoryOnMemorySupportByChunk.scala
@@ -6,22 +6,20 @@ import org.sisioh.dddbase.core.model._
 import scala.util._
 
 /**
-  * [[org.sisioh.dddbase.core.lifecycle.memory.sync.SyncRepositoryOnMemorySupport]]に
-  * [[org.sisioh.dddbase.core.lifecycle.EntitiesChunk]]ための機能を追加するトレイト。
-  *
-  * @tparam R 当該リポジトリを実装する派生型
-  * @tparam ID エンティティの識別子の型
-  * @tparam T エンティティの型
-  */
+ * [[org.sisioh.dddbase.core.lifecycle.memory.sync.SyncRepositoryOnMemorySupport]]に
+ * [[org.sisioh.dddbase.core.lifecycle.EntitiesChunk]]ための機能を追加するトレイト。
+ *
+ * @tparam ID エンティティの識別子の型
+ * @tparam T エンティティの型
+ */
 trait SyncRepositoryOnMemorySupportByChunk
-[+R <: SyncRepository[_, ID, T],
- ID <: Identity[_],
- T <: Entity[ID] with EntityCloneable[ID, T] with Ordered[T]]
-  extends SyncRepositoryOnMemorySupport[R, ID, T] with SyncEntityReaderByChunk[ID, T] {
+[ID <: Identity[_],
+T <: Entity[ID] with EntityCloneable[ID, T] with Ordered[T]]
+  extends SyncRepositoryOnMemorySupport[ID, T] with SyncEntityReaderByChunk[ID, T] {
 
-     def resolveChunk(index: Int, maxEntities: Int): Try[EntitiesChunk[ID, T]] = {
-       val subEntities = toList.slice(index * maxEntities, index * maxEntities + maxEntities)
-       Success(EntitiesChunk(index, subEntities))
-     }
+  def resolveChunk(index: Int, maxEntities: Int): Try[EntitiesChunk[ID, T]] = {
+    val subEntities = toList.slice(index * maxEntities, index * maxEntities + maxEntities)
+    Success(EntitiesChunk(index, subEntities))
+  }
 
-   }
+}

--- a/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/memory/sync/SyncRepositoryOnMemorySupportByOption.scala
+++ b/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/memory/sync/SyncRepositoryOnMemorySupportByOption.scala
@@ -3,35 +3,30 @@ package org.sisioh.dddbase.core.lifecycle.memory.sync
 import org.sisioh.dddbase.core.lifecycle.sync._
 import org.sisioh.dddbase.core.model._
 import scala.Some
-import scala.Some
-import scala.Some
-import scala.Some
 import scala.util._
 
 /**
-  * [[org.sisioh.dddbase.core.lifecycle.memory.sync.SyncRepositoryOnMemorySupport]]にOption型のサポートを追加するトレイト。
-  *
-  * @tparam R 当該リポジトリを実装する派生型
-  * @tparam ID エンティティの識別子の型
-  * @tparam T エンティティの型
-  */
+ * [[org.sisioh.dddbase.core.lifecycle.memory.sync.SyncRepositoryOnMemorySupport]]にOption型のサポートを追加するトレイト。
+ *
+ * @tparam ID エンティティの識別子の型
+ * @tparam T エンティティの型
+ */
 trait SyncRepositoryOnMemorySupportByOption
-[+R <: SyncRepository[_, ID, T],
- ID <: Identity[_],
- T <: Entity[ID] with EntityCloneable[ID, T] with Ordered[T]]
-  extends SyncRepositoryOnMemorySupport[R, ID, T]
-     with SyncEntityReaderByOption[ID, T] {
+[ID <: Identity[_],
+T <: Entity[ID] with EntityCloneable[ID, T] with Ordered[T]]
+  extends SyncRepositoryOnMemorySupport[ID, T]
+  with SyncEntityReaderByOption[ID, T] {
 
-     override def resolveOption(identity: ID) = synchronized {
-       contains(identity).flatMap {
-         _ =>
-           Try {
-             Some(entities(identity).clone)
-           }.recoverWith {
-             case ex: NoSuchElementException =>
-               Success(None)
-           }
-       }
-     }
+  override def resolveOption(identity: ID) = synchronized {
+    contains(identity).flatMap {
+      _ =>
+        Try {
+          Some(entities(identity).clone)
+        }.recoverWith {
+          case ex: NoSuchElementException =>
+            Success(None)
+        }
+    }
+  }
 
-   }
+}

--- a/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/memory/sync/SyncRepositoryOnMemorySupportByPredicate.scala
+++ b/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/memory/sync/SyncRepositoryOnMemorySupportByPredicate.scala
@@ -9,15 +9,13 @@ import scala.util._
  * [[org.sisioh.dddbase.core.lifecycle.memory.sync.SyncRepositoryOnMemorySupport]]に
  * [[org.sisioh.dddbase.core.lifecycle.sync.SyncEntityReaderByPredicate]]ための機能を追加するトレイト。
  *
- * @tparam R 当該リポジトリを実装する派生型
  * @tparam ID エンティティの識別子の型
  * @tparam T エンティティの型
  */
 trait SyncRepositoryOnMemorySupportByPredicate
-[+R <: SyncRepository[_, ID, T],
-ID <: Identity[_],
+[ID <: Identity[_],
 T <: Entity[ID] with EntityCloneable[ID, T] with Ordered[T]]
-  extends SyncRepositoryOnMemorySupport[R, ID, T]
+  extends SyncRepositoryOnMemorySupport[ID, T]
   with SyncEntityReaderByPredicate[ID, T] {
 
   def filterByPredicate

--- a/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/sync/SyncEntityWriter.scala
+++ b/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/sync/SyncEntityWriter.scala
@@ -28,8 +28,10 @@ import org.sisioh.dddbase.core.lifecycle.{RepositoryWithEntity, EntityWriter}
  * @tparam ID 識別子の型
  * @tparam T エンティティの型
  */
-trait SyncEntityWriter[+R <: SyncEntityWriter[_, ID, T], ID <: Identity[_], T <: Entity[ID]]
-  extends EntityWriter[R, ID, T, Try] {
+trait SyncEntityWriter[ID <: Identity[_], T <: Entity[ID]]
+  extends EntityWriter[ID, T, Try] {
+
+  type R <: SyncEntityWriter[ID, T]
 
   /**
    * エンティティを保存する。

--- a/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/sync/SyncRepository.scala
+++ b/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/sync/SyncRepository.scala
@@ -30,10 +30,14 @@ import scala.util._
  * @tparam T エンティティの型
  * @tparam ID エンティティの識別子の型
  */
-trait SyncRepository[+R <: SyncRepository[_, ID, T], ID <: Identity[_], T <: Entity[ID]]
-  extends Repository[R, ID, T, Try]
+trait SyncRepository[ID <: Identity[_], T <: Entity[ID]]
+  extends Repository[ID, T, Try]
   with SyncEntityReader[ID, T]
-  with SyncEntityWriter[R, ID, T]
+  with SyncEntityWriter[ID, T] {
+
+  type R <: SyncRepository[ID, T]
+
+}
 
 
 

--- a/scala-dddbase-core/src/test/scala/org/sisioh/dddbase/core/lifecycle/forwarding/async/ForwardingAsyncRepositorySpec.scala
+++ b/scala-dddbase-core/src/test/scala/org/sisioh/dddbase/core/lifecycle/forwarding/async/ForwardingAsyncRepositorySpec.scala
@@ -28,11 +28,9 @@ class ForwardingAsyncRepositorySpec extends Specification with Mockito {
 
   class TestRepForwardingRepositoryImplAsync
   (protected val delegateAsyncRepository: AsyncRepository[Identity[UUID], EntityImpl])
-  (implicit _executor: ExecutionContext)
+  (implicit val executor: ExecutionContext)
     extends ForwardingAsyncRepository[Identity[UUID], EntityImpl] {
     type R = TestRepForwardingRepositoryImplAsync
-
-    implicit val executor: ExecutionContext = _executor
 
     protected def createInstance
     (state: Future[(R, Option[EntityImpl])]): Future[(TestRepForwardingRepositoryImplAsync, Option[EntityImpl])] = {

--- a/scala-dddbase-core/src/test/scala/org/sisioh/dddbase/core/lifecycle/forwarding/async/ForwardingAsyncRepositorySpec.scala
+++ b/scala-dddbase-core/src/test/scala/org/sisioh/dddbase/core/lifecycle/forwarding/async/ForwardingAsyncRepositorySpec.scala
@@ -27,17 +27,18 @@ class ForwardingAsyncRepositorySpec extends Specification with Mockito {
   val id = Identity(UUID.randomUUID)
 
   class TestRepForwardingRepositoryImplAsync
-  (protected val delegateAsyncRepository: AsyncRepository[_, Identity[UUID], EntityImpl])
+  (protected val delegateAsyncRepository: AsyncRepository[Identity[UUID], EntityImpl])
   (implicit _executor: ExecutionContext)
-    extends ForwardingAsyncRepository[TestRepForwardingRepositoryImplAsync, Identity[UUID], EntityImpl] {
+    extends ForwardingAsyncRepository[Identity[UUID], EntityImpl] {
+    type R = TestRepForwardingRepositoryImplAsync
 
     implicit val executor: ExecutionContext = _executor
 
     protected def createInstance
-    (state: Future[(AsyncEntityWriter[_, Identity[UUID], EntityImpl], Option[EntityImpl])]): Future[(TestRepForwardingRepositoryImplAsync, Option[EntityImpl])] = {
+    (state: Future[(R, Option[EntityImpl])]): Future[(TestRepForwardingRepositoryImplAsync, Option[EntityImpl])] = {
       state.map {
         r =>
-          val state = new TestRepForwardingRepositoryImplAsync(r._1.asInstanceOf[AsyncRepository[_, Identity[UUID], EntityImpl]])
+          val state = new TestRepForwardingRepositoryImplAsync(r._1.asInstanceOf[AsyncRepository[Identity[UUID], EntityImpl]])
           (state, r._2)
       }
     }

--- a/scala-dddbase-core/src/test/scala/org/sisioh/dddbase/core/lifecycle/forwarding/sync/ForwardingSyncRepositorySpec.scala
+++ b/scala-dddbase-core/src/test/scala/org/sisioh/dddbase/core/lifecycle/forwarding/sync/ForwardingSyncRepositorySpec.scala
@@ -25,14 +25,16 @@ class ForwardingSyncRepositorySpec extends Specification with Mockito {
   val id = Identity(UUID.randomUUID())
 
   class TestRepForwardingSyncRepositoryImpl
-  (protected val delegateRepository: SyncRepository[_, Identity[UUID], EntityImpl])
-    extends ForwardingSyncRepository[TestRepForwardingSyncRepositoryImpl, Identity[UUID], EntityImpl] {
+  (protected val delegateRepository: SyncRepository[Identity[UUID], EntityImpl])
+    extends ForwardingSyncRepository[Identity[UUID], EntityImpl] {
 
-    protected def createInstance(state: Try[(SyncEntityWriter[_, Identity[UUID], EntityImpl], Option[EntityImpl])]):
+    type R = TestRepForwardingSyncRepositoryImpl
+
+    protected def createInstance(state: Try[(R, Option[EntityImpl])]):
     Try[(TestRepForwardingSyncRepositoryImpl, Option[EntityImpl])] = {
       state.map {
         r =>
-          val state = new TestRepForwardingSyncRepositoryImpl(r._1.asInstanceOf[SyncRepository[_, Identity[UUID], EntityImpl]])
+          val state = new TestRepForwardingSyncRepositoryImpl(r._1.asInstanceOf[SyncRepository[Identity[UUID], EntityImpl]])
           (state, r._2)
       }
     }

--- a/scala-dddbase-core/src/test/scala/org/sisioh/dddbase/core/lifecycle/memory/mutable/async/TestAsyncRepository.scala
+++ b/scala-dddbase-core/src/test/scala/org/sisioh/dddbase/core/lifecycle/memory/mutable/async/TestAsyncRepository.scala
@@ -4,13 +4,6 @@ import java.util.UUID
 import org.sisioh.dddbase.core.lifecycle.async.AsyncRepository
 import org.sisioh.dddbase.core.model.Identity
 
-/**
- * Created with IntelliJ IDEA.
- * User: junichi
- * Date: 2013/07/14
- * Time: 12:29
- * To change this template use File | Settings | File Templates.
- */
 trait TestAsyncRepository
   extends AsyncRepository[Identity[UUID], TestEntity] {
 }

--- a/scala-dddbase-core/src/test/scala/org/sisioh/dddbase/core/lifecycle/memory/mutable/async/TestAsyncRepository.scala
+++ b/scala-dddbase-core/src/test/scala/org/sisioh/dddbase/core/lifecycle/memory/mutable/async/TestAsyncRepository.scala
@@ -1,8 +1,8 @@
 package org.sisioh.dddbase.core.lifecycle.memory.mutable.async
 
+import java.util.UUID
 import org.sisioh.dddbase.core.lifecycle.async.AsyncRepository
 import org.sisioh.dddbase.core.model.Identity
-import java.util.UUID
 
 /**
  * Created with IntelliJ IDEA.
@@ -12,6 +12,5 @@ import java.util.UUID
  * To change this template use File | Settings | File Templates.
  */
 trait TestAsyncRepository
-  extends AsyncRepository[TestAsyncRepository, Identity[UUID], TestEntity] {
-
+  extends AsyncRepository[Identity[UUID], TestEntity] {
 }

--- a/scala-dddbase-core/src/test/scala/org/sisioh/dddbase/core/lifecycle/memory/mutable/async/TestAsyncRepositoryOnMemory.scala
+++ b/scala-dddbase-core/src/test/scala/org/sisioh/dddbase/core/lifecycle/memory/mutable/async/TestAsyncRepositoryOnMemory.scala
@@ -1,17 +1,16 @@
 package org.sisioh.dddbase.core.lifecycle.memory.mutable.async
 
 import java.util.UUID
-import org.sisioh.dddbase.core.lifecycle.async.AsyncRepository
 import org.sisioh.dddbase.core.lifecycle.memory.mutable.sync.GenericSyncRepositoryOnMemory
-import org.sisioh.dddbase.core.model.{EntityCloneable, Entity, Identity}
+import org.sisioh.dddbase.core.model.Identity
 import scala.concurrent.ExecutionContext
 
 class TestAsyncRepositoryOnMemory
 (protected val core: GenericSyncRepositoryOnMemory[Identity[UUID], TestEntity] = GenericSyncRepositoryOnMemory[Identity[UUID], TestEntity]())
 (implicit _executor: ExecutionContext)
   extends TestAsyncRepository
-  with AsyncRepositoryOnMemory[TestAsyncRepository, GenericSyncRepositoryOnMemory[Identity[UUID], TestEntity], Identity[UUID], TestEntity] {
-
+  with AsyncRepositoryOnMemory[GenericSyncRepositoryOnMemory[Identity[UUID], TestEntity], Identity[UUID], TestEntity] {
+  override type R = TestAsyncRepositoryOnMemory
   implicit val executor: ExecutionContext = _executor
 
 }

--- a/scala-dddbase-core/src/test/scala/org/sisioh/dddbase/core/lifecycle/memory/mutable/async/TestAsyncRepositoryOnMemory.scala
+++ b/scala-dddbase-core/src/test/scala/org/sisioh/dddbase/core/lifecycle/memory/mutable/async/TestAsyncRepositoryOnMemory.scala
@@ -7,10 +7,10 @@ import scala.concurrent.ExecutionContext
 
 class TestAsyncRepositoryOnMemory
 (protected val core: GenericSyncRepositoryOnMemory[Identity[UUID], TestEntity] = GenericSyncRepositoryOnMemory[Identity[UUID], TestEntity]())
-(implicit _executor: ExecutionContext)
+(implicit val executor: ExecutionContext)
   extends TestAsyncRepository
   with AsyncRepositoryOnMemory[GenericSyncRepositoryOnMemory[Identity[UUID], TestEntity], Identity[UUID], TestEntity] {
+
   override type R = TestAsyncRepositoryOnMemory
-  implicit val executor: ExecutionContext = _executor
 
 }

--- a/scala-dddbase-core/src/test/scala/org/sisioh/dddbase/core/lifecycle/memory/mutable/sync/GenericSyncRepositoryOnMemoryByChunkSpec.scala
+++ b/scala-dddbase-core/src/test/scala/org/sisioh/dddbase/core/lifecycle/memory/mutable/sync/GenericSyncRepositoryOnMemoryByChunkSpec.scala
@@ -1,6 +1,5 @@
 package org.sisioh.dddbase.core.lifecycle.memory.mutable.sync
 
-import org.sisioh.dddbase.core.lifecycle.memory.mutable.sync._
 import org.sisioh.dddbase.core.model.{Identity, EntityCloneable, Entity}
 import org.specs2.mock.Mockito
 import org.specs2.mutable._
@@ -19,8 +18,10 @@ class GenericSyncRepositoryOnMemoryByChunkSpec extends Specification with Mockit
   }
 
   class TestSyncRepository
-    extends GenericSyncRepositoryOnMemory[Identity[Int], EntityImpl]
-    with SyncRepositoryOnMemorySupportByChunk[TestSyncRepository, Identity[Int], EntityImpl]
+    extends SyncRepositoryOnMemorySupport[Identity[Int], EntityImpl]
+    with SyncRepositoryOnMemorySupportByChunk[Identity[Int], EntityImpl] {
+    override type R = TestSyncRepository
+  }
 
   "The repository" should {
     "have stored entities" in {

--- a/scala-dddbase-core/src/test/scala/org/sisioh/dddbase/core/lifecycle/memory/mutable/sync/GenericSyncRepositoryOnMemoryByPredicateSpec.scala
+++ b/scala-dddbase-core/src/test/scala/org/sisioh/dddbase/core/lifecycle/memory/mutable/sync/GenericSyncRepositoryOnMemoryByPredicateSpec.scala
@@ -18,8 +18,10 @@ class GenericSyncRepositoryOnMemoryByPredicateSpec extends Specification with Mo
   }
 
   class TestSyncRepository
-    extends GenericSyncRepositoryOnMemory[Identity[Int], EntityImpl]
-    with SyncRepositoryOnMemorySupportByPredicate[TestSyncRepository, Identity[Int], EntityImpl]
+    extends SyncRepositoryOnMemorySupport[Identity[Int], EntityImpl]
+    with SyncRepositoryOnMemorySupportByPredicate[Identity[Int], EntityImpl] {
+    override type R = TestSyncRepository
+  }
 
   "The repository" should {
     "have stored entities" in {

--- a/scala-dddbase-core/src/test/scala/org/sisioh/dddbase/core/lifecycle/memory/mutable/sync/GenericSyncRepositoryOnMemorySpec.scala
+++ b/scala-dddbase-core/src/test/scala/org/sisioh/dddbase/core/lifecycle/memory/mutable/sync/GenericSyncRepositoryOnMemorySpec.scala
@@ -2,13 +2,10 @@ package org.sisioh.dddbase.core.lifecycle.memory.mutable.sync
 
 import java.util.UUID
 import org.sisioh.dddbase.core.lifecycle.EntityNotFoundException
-import org.sisioh.dddbase.core.lifecycle.EntityNotFoundException
-import org.sisioh.dddbase.core.lifecycle.memory.mutable.sync._
 import org.sisioh.dddbase.core.model.{EmptyIdentity, Identity, EntityCloneable, Entity}
 import org.specs2.mock.Mockito
 import org.specs2.mutable._
 import scala.Some
-import scala.util.Failure
 
 class GenericSyncRepositoryOnMemorySpec extends Specification with Mockito {
 
@@ -51,8 +48,11 @@ class GenericSyncRepositoryOnMemorySpec extends Specification with Mockito {
       repos.flatMap(_.repository.resolve(id)).get must_== entity
     }
     "resolveOption a entity by using identity" in {
-      class TestSyncRepository extends GenericSyncRepositoryOnMemory[Identity[UUID], EntityImpl]
-      with SyncRepositoryOnMemorySupportByOption[TestSyncRepository, Identity[UUID], EntityImpl]
+      class TestSyncRepository
+        extends SyncRepositoryOnMemorySupport[Identity[UUID], EntityImpl]
+        with SyncRepositoryOnMemorySupportByOption[Identity[UUID], EntityImpl] {
+        override type R = TestSyncRepository
+      }
       val repository = new TestSyncRepository
       val entity = spy(new EntityImpl(id))
       val repos = repository.store(entity)

--- a/scala-dddbase-core/src/test/scala/org/sisioh/dddbase/core/lifecycle/memory/sync/GenericSyncRepositoryOnMemorySpec.scala
+++ b/scala-dddbase-core/src/test/scala/org/sisioh/dddbase/core/lifecycle/memory/sync/GenericSyncRepositoryOnMemorySpec.scala
@@ -2,8 +2,6 @@ package org.sisioh.dddbase.core.lifecycle.memory.sync
 
 import java.util.UUID
 import org.sisioh.dddbase.core.lifecycle.EntityNotFoundException
-import org.sisioh.dddbase.core.lifecycle.EntityNotFoundException
-import org.sisioh.dddbase.core.lifecycle.memory.sync._
 import org.sisioh.dddbase.core.model.{EmptyIdentity, Identity, EntityCloneable, Entity}
 import org.specs2.mock.Mockito
 import org.specs2.mutable._
@@ -47,8 +45,12 @@ class GenericSyncRepositoryOnMemorySpec extends Specification with Mockito {
       repos.flatMap(_.repository.resolve(id)).get must_== entity
     }
     "resolveOption a entity by using identity" in {
-      class TestSyncRepository extends GenericSyncRepositoryOnMemory[Identity[UUID], EntityImpl]
-      with SyncRepositoryOnMemorySupportByOption[TestSyncRepository, Identity[UUID], EntityImpl]
+      class TestSyncRepository
+        extends SyncRepositoryOnMemorySupport[Identity[UUID], EntityImpl]
+        with SyncRepositoryOnMemorySupportByOption[Identity[UUID], EntityImpl] {
+        override type R = TestSyncRepository
+      }
+
       val repository = new TestSyncRepository
       val entity = spy(new EntityImpl(id))
       val repos = repository.store(entity)

--- a/scala-dddbase-core/src/test/scala/org/sisioh/dddbase/core/lifecycle/memory/sync/SyncRepositoryOnMemorySupportByChunk2Spec.scala
+++ b/scala-dddbase-core/src/test/scala/org/sisioh/dddbase/core/lifecycle/memory/sync/SyncRepositoryOnMemorySupportByChunk2Spec.scala
@@ -1,6 +1,5 @@
 package org.sisioh.dddbase.core.lifecycle.memory.sync
 
-import org.sisioh.dddbase.core.lifecycle.memory.sync._
 import org.sisioh.dddbase.core.model._
 import org.specs2.mock.Mockito
 import org.specs2.mutable.Specification
@@ -16,8 +15,10 @@ class SyncRepositoryOnMemorySupportByChunk2Spec extends Specification with Mocki
     with EntityOrdered[Int, IntIdentity, EntityImpl]
 
   class TestSyncRepository
-    extends GenericSyncRepositoryOnMemory[IntIdentity, EntityImpl]()
-    with SyncRepositoryOnMemorySupportByChunk[TestSyncRepository, IntIdentity, EntityImpl]
+    extends SyncRepositoryOnMemorySupport[IntIdentity, EntityImpl]()
+    with SyncRepositoryOnMemorySupportByChunk[IntIdentity, EntityImpl] {
+    override type R = TestSyncRepository
+  }
 
   "The repository" should {
     "have stored entities" in {

--- a/scala-dddbase-core/src/test/scala/org/sisioh/dddbase/core/lifecycle/memory/sync/SyncRepositoryOnMemorySupportByChunkSpec.scala
+++ b/scala-dddbase-core/src/test/scala/org/sisioh/dddbase/core/lifecycle/memory/sync/SyncRepositoryOnMemorySupportByChunkSpec.scala
@@ -1,6 +1,5 @@
 package org.sisioh.dddbase.core.lifecycle.memory.sync
 
-import org.sisioh.dddbase.core.lifecycle.memory.sync._
 import org.sisioh.dddbase.core.model._
 import org.specs2.mock.Mockito
 import org.specs2.mutable.Specification
@@ -19,8 +18,10 @@ class SyncRepositoryOnMemorySupportByChunkSpec extends Specification with Mockit
   }
 
   class TestSyncRepository
-    extends GenericSyncRepositoryOnMemory[Identity[Int], EntityImpl]()
-    with SyncRepositoryOnMemorySupportByChunk[TestSyncRepository, Identity[Int], EntityImpl]
+    extends SyncRepositoryOnMemorySupport[Identity[Int], EntityImpl]()
+    with SyncRepositoryOnMemorySupportByChunk[Identity[Int], EntityImpl] {
+    override type R = TestSyncRepository
+  }
 
   "The repository" should {
     "have stored entities" in {

--- a/scala-dddbase-core/src/test/scala/org/sisioh/dddbase/core/lifecycle/memory/sync/SyncRepositoryOnMemorySupportByPredicateSpec.scala
+++ b/scala-dddbase-core/src/test/scala/org/sisioh/dddbase/core/lifecycle/memory/sync/SyncRepositoryOnMemorySupportByPredicateSpec.scala
@@ -20,8 +20,10 @@ class SyncRepositoryOnMemorySupportByPredicateSpec extends Specification with Mo
   }
 
   class TestSyncRepository
-    extends GenericSyncRepositoryOnMemory[Identity[Int], EntityImpl]()
-    with SyncRepositoryOnMemorySupportByPredicate[TestSyncRepository, Identity[Int], EntityImpl]
+    extends SyncRepositoryOnMemorySupport[Identity[Int], EntityImpl]()
+    with SyncRepositoryOnMemorySupportByPredicate[Identity[Int], EntityImpl] {
+    override type R = TestSyncRepository
+  }
 
   "The repository" should {
     "have stored entities" in {

--- a/scala-dddbase-event/src/main/scala/org/sisioh/dddbase/event/DomainEventStore.scala
+++ b/scala-dddbase-event/src/main/scala/org/sisioh/dddbase/event/DomainEventStore.scala
@@ -13,6 +13,6 @@ import org.sisioh.dddbase.core.model.Identity
  * @tparam M モナドの型
  * @tparam MR モナドの値の型
  */
-trait DomainEventStore[+R <: Repository[R, ID, T, M], ID <: Identity[_], T <: DomainEvent[ID], M[+A], +MR]
+trait DomainEventStore[+R <: Repository[ID, T, M], ID <: Identity[_], T <: DomainEvent[ID], M[+A], +MR]
   extends DomainEventSubscriber[T, M, MR]
 

--- a/scala-dddbase-event/src/main/scala/org/sisioh/dddbase/event/DomainEventStoreSupport.scala
+++ b/scala-dddbase-event/src/main/scala/org/sisioh/dddbase/event/DomainEventStoreSupport.scala
@@ -12,12 +12,12 @@ import org.sisioh.dddbase.core.model.Identity
  * @tparam T エンティティの型
  * @tparam M モナドの型
  */
-trait DomainEventStoreSupport[+R <: Repository[R, ID, T, M], ID <: Identity[_], T <: DomainEvent[ID], M[+A]]
-  extends DomainEventStore[R, ID, T, M, RepositoryWithEntity[R, T]] {
+trait DomainEventStoreSupport[+R <: Repository[ID, T, M], ID <: Identity[_], T <: DomainEvent[ID], M[+A]]
+  extends DomainEventStore[R, ID, T, M, RepositoryWithEntity[R#R, T]] {
 
   protected val eventRepository: R
 
-  def handleEvent(event: T): M[RepositoryWithEntity[R, T]] =
-    eventRepository.store(event)
-
+  def handleEvent(event: T): M[RepositoryWithEntity[R#R, T]] = {
+    eventRepository.store(event).asInstanceOf[M[RepositoryWithEntity[R#R, T]]]
+  }
 }

--- a/scala-dddbase-event/src/main/scala/org/sisioh/dddbase/event/async/GenericAsyncDomainEventStore.scala
+++ b/scala-dddbase-event/src/main/scala/org/sisioh/dddbase/event/async/GenericAsyncDomainEventStore.scala
@@ -13,7 +13,7 @@ import scala.concurrent.Future
  * @tparam ID エンティティの識別子の型
  * @tparam T エンティティの型
  */
-case class GenericAsyncDomainEventStore[+R <: Repository[R, ID, T, Future], ID <: Identity[_], T <: DomainEvent[ID]]
+case class GenericAsyncDomainEventStore[+R <: Repository[ID, T, Future], ID <: Identity[_], T <: DomainEvent[ID]]
 (protected val eventRepository: R)
   extends DomainEventStoreSupport[R, ID, T, Future] {
 

--- a/scala-dddbase-event/src/main/scala/org/sisioh/dddbase/event/mutable/async/DomainEventStoreSupport.scala
+++ b/scala-dddbase-event/src/main/scala/org/sisioh/dddbase/event/mutable/async/DomainEventStoreSupport.scala
@@ -13,7 +13,7 @@ import scala.concurrent.{Future, ExecutionContext}
  * @tparam T エンティティの型
  */
 trait DomainEventStoreSupport
-[+R <: Repository[R, ID, T, Future],
+[+R <: Repository[ID, T, Future],
 ID <: Identity[_],
 T <: DomainEvent[ID]]
   extends DomainEventStore[R, ID, T, Future, Unit] {

--- a/scala-dddbase-event/src/main/scala/org/sisioh/dddbase/event/mutable/async/GenericAsyncDomainEventStore.scala
+++ b/scala-dddbase-event/src/main/scala/org/sisioh/dddbase/event/mutable/async/GenericAsyncDomainEventStore.scala
@@ -14,6 +14,6 @@ import scala.concurrent.{ExecutionContext, Future}
  * @tparam ID エンティティの識別子の型
  * @tparam T エンティティの型
  */
-case class GenericAsyncDomainEventStore[+R <: Repository[R, ID, T, Future], ID <: Identity[_], T <: DomainEvent[ID]]
+case class GenericAsyncDomainEventStore[+R <: Repository[ID, T, Future], ID <: Identity[_], T <: DomainEvent[ID]]
 (protected val eventRepository: R)(implicit val executor : ExecutionContext)
   extends DomainEventStoreSupport[R, ID, T]

--- a/scala-dddbase-event/src/main/scala/org/sisioh/dddbase/event/mutable/sync/DomainEventStoreSupport.scala
+++ b/scala-dddbase-event/src/main/scala/org/sisioh/dddbase/event/mutable/sync/DomainEventStoreSupport.scala
@@ -13,7 +13,7 @@ import scala.util.Try
  * @tparam T エンティティの型
  */
 trait DomainEventStoreSupport
-[+R <: Repository[R, ID, T, Try],
+[+R <: Repository[ID, T, Try],
 ID <: Identity[_],
 T <: DomainEvent[ID]]
   extends DomainEventStore[R, ID, T, Try, Unit] {

--- a/scala-dddbase-event/src/main/scala/org/sisioh/dddbase/event/mutable/sync/GenericSyncDomainEventStore.scala
+++ b/scala-dddbase-event/src/main/scala/org/sisioh/dddbase/event/mutable/sync/GenericSyncDomainEventStore.scala
@@ -13,7 +13,7 @@ import scala.util.Try
  * @tparam ID エンティティの識別子の型
  * @tparam T エンティティの型
  */
-case class GenericSyncDomainEventStore[+R <: Repository[R, ID, T, Try], ID <: Identity[_], T <: DomainEvent[ID]]
+case class GenericSyncDomainEventStore[+R <: Repository[ID, T, Try], ID <: Identity[_], T <: DomainEvent[ID]]
 (protected val eventRepository: R)
   extends DomainEventStoreSupport[R, ID, T]
 

--- a/scala-dddbase-event/src/main/scala/org/sisioh/dddbase/event/sync/GenericSyncDomainEventStore.scala
+++ b/scala-dddbase-event/src/main/scala/org/sisioh/dddbase/event/sync/GenericSyncDomainEventStore.scala
@@ -13,6 +13,6 @@ import scala.util.Try
  * @tparam ID エンティティの識別子の型
  * @tparam T エンティティの型
  */
-case class GenericSyncDomainEventStore[+R <: Repository[R, ID, T, Try], ID <: Identity[_], T <: DomainEvent[ID]]
+case class GenericSyncDomainEventStore[+R <: Repository[ID, T, Try], ID <: Identity[_], T <: DomainEvent[ID]]
 (protected val eventRepository: R)
   extends DomainEventStoreSupport[R, ID, T, Try]


### PR DESCRIPTION
型パラメータに指定していた 派生型指定を type Rによって回避する変更。
型引数が減ることにより可読性が向上することがメリット。
代わりに、実装クラスでtype Rの具体型を指定することが必須になる。
