### PR TITLE
デコレータとしてのFowarding(Sync/Async)Repositoryの追加など

### DIFF
--- a/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/forwarding/async/ForwardingAsyncEntityReadableByChunk.scala
+++ b/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/forwarding/async/ForwardingAsyncEntityReadableByChunk.scala
@@ -15,12 +15,14 @@ trait ForwardingAsyncEntityReadableByChunk[ID <: Identity[_], E <: Entity[ID]]
   extends AsyncEntityReadableByChunk[ID, E] {
   this: AsyncEntityReader[ID, E] =>
 
+  type Delegate <: AsyncEntityReadableByChunk[ID, E]
+
   /**
    * デリゲート。
    */
-  protected val delegateAsyncEntityReaderByChunk: AsyncEntityReadableByChunk[ID, E]
+  protected val delegate: Delegate
 
   def resolveChunk(index: Int, maxEntities: Int): Future[EntitiesChunk[ID, E]] =
-    delegateAsyncEntityReaderByChunk.resolveChunk(index, maxEntities)
+    delegate.resolveChunk(index, maxEntities)
 
 }

--- a/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/forwarding/async/ForwardingAsyncEntityReader.scala
+++ b/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/forwarding/async/ForwardingAsyncEntityReader.scala
@@ -13,15 +13,17 @@ import scala.concurrent.Future
 trait ForwardingAsyncEntityReader[ID <: Identity[_], E <: Entity[ID]]
   extends AsyncEntityReader[ID, E] {
 
+  type Delegate <: AsyncEntityReader[ID, E]
+
   /**
    * デリゲート。
    */
-  protected val delegateAsyncEntityReader: AsyncEntityReader[ID, E]
+  protected val delegate: Delegate
 
   def resolve(identity: ID) =
-    delegateAsyncEntityReader.resolve(identity)
+    delegate.resolve(identity)
 
   def contains(identity: ID): Future[Boolean] =
-    delegateAsyncEntityReader.contains(identity)
+    delegate.contains(identity)
 
 }

--- a/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/forwarding/async/ForwardingAsyncEntityReaderByOption.scala
+++ b/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/forwarding/async/ForwardingAsyncEntityReaderByOption.scala
@@ -14,9 +14,11 @@ trait ForwardingAsyncEntityReaderByOption[ID <: Identity[_], E <: Entity[ID]]
   extends AsyncEntityReadableByOption[ID, E] {
   this: AsyncEntityReader[ID, E] =>
 
-  protected val delegateAsyncEntityReaderByOption: AsyncEntityReadableByOption[ID, E]
+  type Delegate <: AsyncEntityReadableByOption[ID, E]
+
+  protected val delegate: Delegate
 
   def resolveOption(identity: ID): Future[Option[E]] =
-    delegateAsyncEntityReaderByOption.resolveOption(identity)
+    delegate.resolveOption(identity)
 
 }

--- a/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/forwarding/async/ForwardingAsyncEntityReaderByPredicate.scala
+++ b/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/forwarding/async/ForwardingAsyncEntityReaderByPredicate.scala
@@ -15,14 +15,16 @@ trait ForwardingAsyncEntityReaderByPredicate[ID <: Identity[_], E <: Entity[ID]]
   extends AsyncEntityReadableByPredicate[ID, E] {
   this: AsyncEntityReader[ID, E] =>
 
+  type Delegate <: AsyncEntityReadableByPredicate[ID, E]
+
   /**
    * デリゲート。
    */
-  protected val delegateAsyncEntityReaderByPredicate: AsyncEntityReadableByPredicate[ID, E]
+  protected val delegate: Delegate
 
   def filterByPredicate
   (predicate: (E) => Boolean,
    index: Option[Int], maxEntities: Option[Int]): Future[EntitiesChunk[ID, E]] =
-    delegateAsyncEntityReaderByPredicate.filterByPredicate(predicate, index, maxEntities)
+    delegate.filterByPredicate(predicate, index, maxEntities)
 
 }

--- a/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/forwarding/async/ForwardingAsyncRepository.scala
+++ b/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/forwarding/async/ForwardingAsyncRepository.scala
@@ -1,7 +1,7 @@
 package org.sisioh.dddbase.core.lifecycle.forwarding.async
 
+import org.sisioh.dddbase.core.lifecycle.async.AsyncRepository
 import org.sisioh.dddbase.core.model.{Entity, Identity}
-import org.sisioh.dddbase.core.lifecycle.async.{AsyncRepository, AsyncEntityWriter, AsyncEntityReader}
 
 /**
  * [[org.sisioh.dddbase.core.lifecycle.async.AsyncRepository]]のデコレータ。
@@ -12,16 +12,15 @@ import org.sisioh.dddbase.core.lifecycle.async.{AsyncRepository, AsyncEntityWrit
 trait ForwardingAsyncRepository[ID <: Identity[_], E <: Entity[ID]]
   extends ForwardingAsyncEntityReader[ID, E]
   with ForwardingAsyncEntityWriter[ID, E]
-  with AsyncRepository[ID, E]{
+  with AsyncRepository[ID, E] {
+
+  type Delegate <: AsyncRepository[ID, E]
 
   /**
    * デリゲート。
    */
-  protected val delegateAsyncRepository: AsyncRepository[ID, E]
+  protected val delegate: Delegate
 
-  protected val delegateAsyncEntityReader: AsyncEntityReader[ID, E] = delegateAsyncRepository
-
-  protected val delegateAsyncEntityWriter: AsyncEntityWriter[ID, E] = delegateAsyncRepository
 
 }
 

--- a/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/forwarding/async/wrapped/ForwardingAsyncWrappedEntityReader.scala
+++ b/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/forwarding/async/wrapped/ForwardingAsyncWrappedEntityReader.scala
@@ -1,0 +1,31 @@
+package org.sisioh.dddbase.core.lifecycle.forwarding.async.wrapped
+
+import org.sisioh.dddbase.core.lifecycle.async.AsyncEntityReader
+import org.sisioh.dddbase.core.lifecycle.sync.SyncEntityReader
+import org.sisioh.dddbase.core.model.{Entity, Identity}
+import scala.concurrent._
+
+/**
+ * [[org.sisioh.dddbase.core.lifecycle.sync.SyncEntityReader]]をラップし
+ * [[org.sisioh.dddbase.core.lifecycle.async.AsyncEntityReader]]にするための
+ * デコレータ。
+ *
+ * @tparam ID 識別子の型
+ * @tparam E エンティティの型
+ */
+trait ForwardingAsyncWrappedEntityReader[ID <: Identity[_], E <: Entity[ID]]
+  extends AsyncEntityReader[ID, E] {
+
+  type Delegate <: SyncEntityReader[ID, E]
+
+  protected val delegate: Delegate
+
+  def resolve(identity: ID) = future {
+    delegate.resolve(identity).get
+  }
+
+  def contains(identity: ID): Future[Boolean] = future {
+    delegate.contains(identity).get
+  }
+
+}

--- a/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/forwarding/async/wrapped/ForwardingAsyncWrappedEntityWriter.scala
+++ b/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/forwarding/async/wrapped/ForwardingAsyncWrappedEntityWriter.scala
@@ -1,0 +1,33 @@
+package org.sisioh.dddbase.core.lifecycle.forwarding.async.wrapped
+
+import org.sisioh.dddbase.core.lifecycle.ResultWithEntity
+import org.sisioh.dddbase.core.lifecycle.async.{AsyncResultWithEntity, AsyncEntityWriter}
+import org.sisioh.dddbase.core.lifecycle.sync.SyncEntityWriter
+import org.sisioh.dddbase.core.model.{Entity, Identity}
+import scala.concurrent._
+
+trait ForwardingAsyncWrappedEntityWriter[ID <: Identity[_], E <: Entity[ID]]
+  extends AsyncEntityWriter[ID, E] {
+
+  type Delegate <: SyncEntityWriter[ID, E]
+
+  /**
+   * デリゲート。
+   */
+  protected val delegate: Delegate
+
+  protected def createInstance(state: (Delegate#This, Option[E])): (This, Option[E])
+
+  def store(entity: E): Future[ResultWithEntity[This, ID, E, Future]] = future {
+    val resultWithEntity = delegate.store(entity).get
+    val result = createInstance((resultWithEntity.result.asInstanceOf[Delegate#This], Some(resultWithEntity.entity)))
+    AsyncResultWithEntity[This, ID, E](result._1.asInstanceOf[This], result._2.get)
+  }
+
+  def delete(identity: ID): Future[This] = future {
+    val resultTry = delegate.delete(identity).get
+    val result = createInstance(resultTry.asInstanceOf[Delegate#This], None)
+    result._1
+  }
+
+}

--- a/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/forwarding/async/wrapped/ForwardingAsyncWrappedRepository.scala
+++ b/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/forwarding/async/wrapped/ForwardingAsyncWrappedRepository.scala
@@ -1,0 +1,14 @@
+package org.sisioh.dddbase.core.lifecycle.forwarding.async.wrapped
+
+import org.sisioh.dddbase.core.lifecycle.async.AsyncRepository
+import org.sisioh.dddbase.core.lifecycle.sync.SyncRepository
+import org.sisioh.dddbase.core.model.{Entity, Identity}
+
+trait ForwardingAsyncWrappedRepository[ID <: Identity[_], E <: Entity[ID]]
+  extends ForwardingAsyncWrappedEntityReader[ID, E]
+  with ForwardingAsyncWrappedEntityWriter[ID, E]
+  with AsyncRepository[ID, E] {
+
+  type Delegate <: SyncRepository[ID, E]
+
+}

--- a/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/forwarding/sync/ForwardingSyncEntityReadableByChunk.scala
+++ b/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/forwarding/sync/ForwardingSyncEntityReadableByChunk.scala
@@ -1,9 +1,9 @@
 package org.sisioh.dddbase.core.lifecycle.forwarding.sync
 
 import org.sisioh.dddbase.core.lifecycle.EntitiesChunk
+import org.sisioh.dddbase.core.lifecycle.sync.{SyncEntityReadableByChunk, SyncEntityReader}
 import org.sisioh.dddbase.core.model.{Identity, Entity}
 import scala.util.Try
-import org.sisioh.dddbase.core.lifecycle.sync.{SyncEntityReadableByChunk, SyncEntityReader}
 
 /**
  * [[org.sisioh.dddbase.core.lifecycle.sync.SyncEntityReadableByChunk]]のデコレータ。
@@ -15,13 +15,15 @@ trait ForwardingSyncEntityReadableByChunk[ID <: Identity[_], E <: Entity[ID]]
   extends SyncEntityReadableByChunk[ID, E] {
   this: SyncEntityReader[ID, E] =>
 
+  type Delegate <: SyncEntityReadableByChunk[ID, E]
+
   /**
    * デリゲート。
    */
-  protected val delegateEntityReaderByChunk: SyncEntityReadableByChunk[ID, E]
+  protected val delegate: Delegate
 
   def resolveChunk(index: Int, maxEntities: Int): Try[EntitiesChunk[ID, E]] =
-    delegateEntityReaderByChunk.resolveChunk(index, maxEntities)
+    delegate.resolveChunk(index, maxEntities)
 
 }
 

--- a/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/forwarding/sync/ForwardingSyncEntityReadableByOption.scala
+++ b/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/forwarding/sync/ForwardingSyncEntityReadableByOption.scala
@@ -14,11 +14,13 @@ trait ForwardingSyncEntityReadableByOption[ID <: Identity[_], E <: Entity[ID]]
   extends SyncEntityReadableByOption[ID, E] {
   this: SyncEntityReader[ID, E] =>
 
+  type Delegate <: SyncEntityReadableByOption[ID, E]
+
   /**
    * デリゲート。
    */
-  protected val delegateEntityReaderByOption: SyncEntityReadableByOption[ID, E]
+  protected val delegate: Delegate
 
-  def resolveOption(identity: ID): Try[Option[E]] = delegateEntityReaderByOption.resolveOption(identity)
+  def resolveOption(identity: ID): Try[Option[E]] = delegate.resolveOption(identity)
 
 }

--- a/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/forwarding/sync/ForwardingSyncEntityReadableByPredicate.scala
+++ b/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/forwarding/sync/ForwardingSyncEntityReadableByPredicate.scala
@@ -15,14 +15,16 @@ trait ForwardingSyncEntityReadableByPredicate[ID <: Identity[_], E <: Entity[ID]
   extends SyncEntityReadableByPredicate[ID, E] {
   this: SyncEntityReader[ID, E] =>
 
+  type Delegate <: SyncEntityReadableByPredicate[ID, E]
+
   /**
    * デリゲート。
    */
-  protected val delegateEntityReaderByPredicate: SyncEntityReadableByPredicate[ID, E]
+  protected val delegate: Delegate
 
   def filterByPredicate
   (predicate: (E) => Boolean,
    index: Option[Int], maxEntities: Option[Int]): Try[EntitiesChunk[ID, E]] =
-    delegateEntityReaderByPredicate.filterByPredicate(predicate, index, maxEntities)
+    delegate.filterByPredicate(predicate, index, maxEntities)
 
 }

--- a/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/forwarding/sync/ForwardingSyncEntityReader.scala
+++ b/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/forwarding/sync/ForwardingSyncEntityReader.scala
@@ -13,13 +13,15 @@ import org.sisioh.dddbase.core.lifecycle.sync.SyncEntityReader
 trait ForwardingSyncEntityReader[ID <: Identity[_], E <: Entity[ID]]
   extends SyncEntityReader[ID, E] {
 
+  type Delegate <: SyncEntityReader[ID, E]
+
   /**
    * デリゲート。
    */
-  protected val delegateEntityReader: SyncEntityReader[ID, E]
+  protected val delegate: Delegate
 
-  def resolve(identity: ID): Try[E] = delegateEntityReader.resolve(identity)
+  def resolve(identity: ID): Try[E] = delegate.resolve(identity)
 
-  def contains(identity: ID): Try[Boolean] = delegateEntityReader.contains(identity)
+  def contains(identity: ID): Try[Boolean] = delegate.contains(identity)
 
 }

--- a/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/forwarding/sync/ForwardingSyncEntityWriter.scala
+++ b/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/forwarding/sync/ForwardingSyncEntityWriter.scala
@@ -16,10 +16,12 @@ trait ForwardingSyncEntityWriter[ID <: Identity[_], E <: Entity[ID]]
 
   type This <: ForwardingSyncEntityWriter[ID, E]
 
+  type Delegate <: SyncEntityWriter[ID, E]
+
   /**
    * デリゲート。
    */
-  protected val delegateEntityWriter: SyncEntityWriter[ID, E]
+  protected val delegate: Delegate
 
   /**
    * 新しいインスタンスを作成する。
@@ -27,22 +29,22 @@ trait ForwardingSyncEntityWriter[ID <: Identity[_], E <: Entity[ID]]
    * @param state 新しい状態のデリゲートとエンティティ
    * @return 新しいインスタンスとエンティティ
    */
-  protected def createInstance(state: Try[(SyncEntityWriter[ID, E]#This, Option[E])]): Try[(This, Option[E])]
+  protected def createInstance(state: Try[(Delegate#This, Option[E])]): Try[(This, Option[E])]
 
   def store(entity: E): Try[ResultWithEntity[This, ID, E, Try]] = {
     createInstance(
-      delegateEntityWriter.store(entity).map {
+      delegate.store(entity).map {
         e =>
-          (e.result, Some(e.entity))
+          (e.result.asInstanceOf[Delegate#This], Some(e.entity))
       }
     ).map(e => SyncResultWithEntity(e._1, e._2.get))
   }
 
   def delete(identity: ID): Try[This] = {
     createInstance(
-      delegateEntityWriter.delete(identity).map {
+      delegate.delete(identity).map {
         e =>
-          (e, None)
+          (e.asInstanceOf[Delegate#This], None)
       }
     ).map(e => e._1)
   }

--- a/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/forwarding/sync/ForwardingSyncRepository.scala
+++ b/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/forwarding/sync/ForwardingSyncRepository.scala
@@ -16,13 +16,11 @@ trait ForwardingSyncRepository[ID <: Identity[_], E <: Entity[ID]]
 
   type This <: ForwardingSyncRepository[ID, E]
 
+  type Delegate <: SyncRepository[ID, E]
+
   /**
    * デリゲート。
    */
-  protected val delegateRepository: SyncRepository[ID, E]
-
-  protected val delegateEntityReader: SyncEntityReader[ID, E] = delegateRepository
-
-  protected val delegateEntityWriter: SyncEntityWriter[ID, E] = delegateRepository
+  protected val delegate: Delegate
 
 }

--- a/scala-dddbase-core/src/test/scala/org/sisioh/dddbase/core/lifecycle/forwarding/async/ForwardingAsyncRepositorySpec.scala
+++ b/scala-dddbase-core/src/test/scala/org/sisioh/dddbase/core/lifecycle/forwarding/async/ForwardingAsyncRepositorySpec.scala
@@ -2,7 +2,7 @@ package org.sisioh.dddbase.core.lifecycle.forwarding.async
 
 import java.util.UUID
 import org.sisioh.dddbase.core.lifecycle.EntityNotFoundException
-import org.sisioh.dddbase.core.lifecycle.async.{AsyncEntityWriter, AsyncRepository}
+import org.sisioh.dddbase.core.lifecycle.async.AsyncRepository
 import org.sisioh.dddbase.core.lifecycle.memory.async.GenericAsyncRepositoryOnMemory
 import org.sisioh.dddbase.core.model.{EntityCloneable, Entity, Identity}
 import org.specs2.mock.Mockito
@@ -27,16 +27,18 @@ class ForwardingAsyncRepositorySpec extends Specification with Mockito {
   val id = Identity(UUID.randomUUID)
 
   class TestRepForwardingRepositoryImpl
-  (protected val delegateAsyncRepository: AsyncRepository[Identity[UUID], EntityImpl])
+  (protected val delegate: AsyncRepository[Identity[UUID], EntityImpl])
   (implicit val executor: ExecutionContext)
     extends ForwardingAsyncRepository[Identity[UUID], EntityImpl] {
 
     type This = TestRepForwardingRepositoryImpl
 
-    protected def createInstance(state: Future[(AsyncEntityWriter[Identity[UUID], EntityImpl], Option[EntityImpl])]): Future[(This, Option[EntityImpl])] = {
+    type Delegate = AsyncRepository[Identity[UUID], EntityImpl]
+
+    protected def createInstance(state: Future[(Delegate#This, Option[EntityImpl])]): Future[(This, Option[EntityImpl])] = {
       state.map {
         r =>
-          val state = new TestRepForwardingRepositoryImpl(r._1.asInstanceOf[AsyncRepository[Identity[UUID], EntityImpl]])
+          val state = new TestRepForwardingRepositoryImpl(r._1.asInstanceOf[Delegate#This])
           (state, r._2)
       }
     }

--- a/scala-dddbase-core/src/test/scala/org/sisioh/dddbase/core/lifecycle/forwarding/async/wrapped/ForwardingAsyncWrappedRepositorySpec.scala
+++ b/scala-dddbase-core/src/test/scala/org/sisioh/dddbase/core/lifecycle/forwarding/async/wrapped/ForwardingAsyncWrappedRepositorySpec.scala
@@ -1,0 +1,96 @@
+package org.sisioh.dddbase.core.lifecycle.forwarding.async.wrapped
+
+import java.util.UUID
+import org.sisioh.dddbase.core.lifecycle.EntityNotFoundException
+import org.sisioh.dddbase.core.lifecycle.memory.mutable.sync.GenericSyncRepositoryOnMemory
+import org.sisioh.dddbase.core.model.{EmptyIdentity, EntityCloneable, Entity, Identity}
+import org.specs2.mock.Mockito
+import org.specs2.mutable.Specification
+import scala.concurrent.duration.Duration
+import scala.concurrent.{Await, ExecutionContext}
+import ExecutionContext.Implicits.global
+
+class ForwardingAsyncWrappedRepositorySpec extends Specification with Mockito {
+
+  class EntityImpl(val identity: Identity[UUID])
+    extends Entity[Identity[UUID]]
+    with EntityCloneable[Identity[UUID], EntityImpl]
+    with Ordered[EntityImpl] {
+    def compare(that: EntityImpl): Int = {
+      identity.value.compareTo(that.identity.value)
+    }
+  }
+
+  class ForwardingAsyncWrappedRepositoryImpl
+  (implicit val executor: ExecutionContext)
+    extends ForwardingAsyncWrappedRepository[Identity[UUID], EntityImpl] {
+
+    type This = ForwardingAsyncWrappedRepositoryImpl
+
+    type Delegate = GenericSyncRepositoryOnMemory[Identity[UUID], EntityImpl]
+
+    protected val delegate: GenericSyncRepositoryOnMemory[Identity[UUID], EntityImpl] =
+      GenericSyncRepositoryOnMemory[Identity[UUID], EntityImpl]
+
+    protected def createInstance(state: (Delegate#This, Option[EntityImpl])): (This, Option[EntityImpl]) = {
+      (this.asInstanceOf[This], state._2)
+    }
+
+  }
+
+
+  val id = Identity(UUID.randomUUID)
+
+  "The repository" should {
+    "have stored entity with empty identity" in {
+      val repository = new ForwardingAsyncWrappedRepositoryImpl
+      val entity = spy(new EntityImpl(EmptyIdentity))
+      val repos = repository.store(entity)
+      Await.ready(repos, Duration.Inf)
+      there was atLeastOne(entity).identity
+      Await.result(repository.resolve(EmptyIdentity), Duration.Inf) must_== entity
+      Await.result(repos.flatMap(_.result.contains(entity)), Duration.Inf) must_== true
+    }
+    "have stored entity" in {
+      val repository = new ForwardingAsyncWrappedRepositoryImpl
+      val entity = spy(new EntityImpl(id))
+      val repos = repository.store(entity)
+      Await.ready(repos, Duration.Inf)
+      there was atLeastOne(entity).identity
+      Await.result(repository.resolve(id), Duration.Inf) must_== entity
+      Await.result(repos.flatMap(_.result.contains(entity)), Duration.Inf) must_== true
+    }
+    "resolve a entity by using identity" in {
+      val repository = new ForwardingAsyncWrappedRepositoryImpl
+      val entity = spy(new EntityImpl(id))
+      val repos = repository.store(entity)
+      Await.ready(repos, Duration.Inf)
+      there was atLeastOne(entity).identity
+      Await.result(repository.resolve(id), Duration.Inf) must_== entity
+      Await.result(repos.flatMap(_.result.resolve(id)), Duration.Inf) must_== entity
+    }
+    "delete a entity by using identity" in {
+      val repository = new ForwardingAsyncWrappedRepositoryImpl
+      val entity = spy(new EntityImpl(id))
+      val repos = repository.store(entity)
+      Await.ready(repos, Duration.Inf)
+      there was atLeastOne(entity).identity
+      Await.result(repository.resolve(id), Duration.Inf) must_== entity
+      Await.result(repos.flatMap(_.result.delete(id)), Duration.Inf) must_!= repos
+    }
+    "fail to resolve a entity by a non-existent identity" in {
+      val repository = new ForwardingAsyncWrappedRepositoryImpl
+      Await.result(repository.resolve(id).recover {
+        case ex: EntityNotFoundException => true
+      }, Duration.Inf) must_== true
+      Await.result(repository.resolve(id), Duration.Inf) must throwA[EntityNotFoundException]
+    }
+    "fail to delete a entity by a non-existent identity" in {
+      val repository = new ForwardingAsyncWrappedRepositoryImpl
+      Await.result(repository.delete(id).recover {
+        case ex: EntityNotFoundException => true
+      }, Duration.Inf) must_== true
+      Await.result(repository.delete(id), Duration.Inf) must throwA[EntityNotFoundException]
+    }
+  }
+}

--- a/scala-dddbase-core/src/test/scala/org/sisioh/dddbase/core/lifecycle/forwarding/sync/ForwardingSyncRepositorySpec.scala
+++ b/scala-dddbase-core/src/test/scala/org/sisioh/dddbase/core/lifecycle/forwarding/sync/ForwardingSyncRepositorySpec.scala
@@ -25,18 +25,21 @@ class ForwardingSyncRepositorySpec extends Specification with Mockito {
   val id = Identity(UUID.randomUUID())
 
   class TestRepForwardingSyncRepositoryImpl
-  (protected val delegateRepository: SyncRepository[Identity[UUID], EntityImpl])
+  (protected val delegate: SyncRepository[Identity[UUID], EntityImpl])
     extends ForwardingSyncRepository[Identity[UUID], EntityImpl] {
 
     type This = TestRepForwardingSyncRepositoryImpl
 
-    protected def createInstance(state: Try[(SyncEntityWriter[Identity[UUID], EntityImpl]#This, Option[EntityImpl])]): Try[(TestRepForwardingSyncRepositoryImpl#This, Option[EntityImpl])] = {
+    type Delegate = SyncRepository[Identity[UUID], EntityImpl]
+
+    protected def createInstance(state: Try[(Delegate#This, Option[EntityImpl])]): Try[(TestRepForwardingSyncRepositoryImpl#This, Option[EntityImpl])] = {
       state.map {
         r =>
           val state = new TestRepForwardingSyncRepositoryImpl(r._1.asInstanceOf[SyncRepository[Identity[UUID], EntityImpl]])
           (state, r._2)
       }
     }
+
   }
 
   "The repository" should {

--- a/scala-dddbase-core/src/test/scala/org/sisioh/dddbase/core/lifecycle/memory/mutable/async/GenericAsyncRepositoryOnMemorySpec.scala
+++ b/scala-dddbase-core/src/test/scala/org/sisioh/dddbase/core/lifecycle/memory/mutable/async/GenericAsyncRepositoryOnMemorySpec.scala
@@ -29,8 +29,8 @@ class GenericAsyncRepositoryOnMemorySpec extends Specification with Mockito {
       val repository = new GenericAsyncRepositoryOnMemory[Identity[UUID], EntityImpl]()
       val entity = spy(new EntityImpl(EmptyIdentity))
       val repos = repository.store(entity)
-      there was atLeastOne(entity).identity
       Await.ready(repos, Duration.Inf)
+      there was atLeastOne(entity).identity
       Await.result(repository.resolve(EmptyIdentity), Duration.Inf) must_== entity
       Await.result(repos.flatMap(_.result.contains(entity)), Duration.Inf) must_== true
     }
@@ -38,8 +38,8 @@ class GenericAsyncRepositoryOnMemorySpec extends Specification with Mockito {
       val repository = new GenericAsyncRepositoryOnMemory[Identity[UUID], EntityImpl]()
       val entity = spy(new EntityImpl(id))
       val repos = repository.store(entity)
-      there was atLeastOne(entity).identity
       Await.ready(repos, Duration.Inf)
+      there was atLeastOne(entity).identity
       Await.result(repository.resolve(id), Duration.Inf) must_== entity
       Await.result(repos.flatMap(_.result.contains(entity)), Duration.Inf) must_== true
     }
@@ -47,8 +47,8 @@ class GenericAsyncRepositoryOnMemorySpec extends Specification with Mockito {
       val repository = new GenericAsyncRepositoryOnMemory[Identity[UUID], EntityImpl]()
       val entity = spy(new EntityImpl(id))
       val repos = repository.store(entity)
-      there was atLeastOne(entity).identity
       Await.ready(repos, Duration.Inf)
+      there was atLeastOne(entity).identity
       Await.result(repository.resolve(id), Duration.Inf) must_== entity
       Await.result(repos.flatMap(_.result.resolve(id)), Duration.Inf) must_== entity
     }
@@ -56,8 +56,8 @@ class GenericAsyncRepositoryOnMemorySpec extends Specification with Mockito {
       val repository = new GenericAsyncRepositoryOnMemory[Identity[UUID], EntityImpl]()
       val entity = spy(new EntityImpl(id))
       val repos = repository.store(entity)
-      there was atLeastOne(entity).identity
       Await.ready(repos, Duration.Inf)
+      there was atLeastOne(entity).identity
       Await.result(repository.resolve(id), Duration.Inf) must_== entity
       Await.result(repos.flatMap(_.result.delete(id)), Duration.Inf) must_!= repos
     }


### PR DESCRIPTION
- delegateのフィールドを一つに統合しました。
- SyncRepositoryをAsyncRepositoryとして修飾するためのデコレータを用意しました。
  https://github.com/sisioh/scala-dddbase/commit/1bf6504398884d2d63588381feb88b9c877b42bd#L0R25
  このようなデコレータを用意することで同期リポジトリを非同期リポジトリ化させることができます。ロジックを同期リポジトリ側に寄せて、非同期リポジトリはデコレータで提供することができます。
