### PR TITLE
Repository#deleteメソッドもResultWithEntityを返すように修正。

### DIFF
--- a/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/EntityWriter.scala
+++ b/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/EntityWriter.scala
@@ -37,17 +37,49 @@ trait EntityWriter[ID <: Identity[_], E <: Entity[ID], M[+A]]
    *
    * @param entity 保存する対象のエンティティ
    * @return Success:
-   *         リポジトリインスタンス
+   *         リポジトリインスタンスと保存されたエンティティ
    *         Failure
    *         RepositoryExceptionは、リポジトリにアクセスできなかった場合。
    */
   def store(entity: E): M[ResultWithEntity[This, ID, E, M]]
 
+  /**
+   * 更新メソッド。
+   *
+   * {{{
+   *   entityWriter(identity) = entity
+   * }}}
+   *
+   * @param identity 識別子
+   * @param entity エンティティ
+   * @return Success:
+   *         リポジトリインスタンスと保存されたエンティティ
+   *         Failure
+   *         RepositoryExceptionは、リポジトリにアクセスできなかった場合。
+   */
   def update(identity: ID, entity: E) = store(entity)
 
-  def delete(identity: ID): M[This]
+  /**
+   * 指定した識別子のエンティティを削除する。
+   *
+   * @param identity 識別子
+   * @return Success:
+   *         リポジトリインスタンスと削除されたエンティティ
+   *         Failure:
+   *         RepositoryExceptionは、リポジトリにアクセスできなかった場合。
+   */
+  def delete(identity: ID): M[ResultWithEntity[This, ID, E, M]]
 
-  def delete(entity: E): M[This] = delete(entity.identity)
+  /**
+   * エンティティを削除する。
+   *
+   * @param entity エンティティ
+   * @return Success:
+   *         リポジトリインスタンスと削除されたエンティティ
+   *         Failure:
+   *         RepositoryExceptionは、リポジトリにアクセスできなかった場合。
+   */
+  def delete(entity: E): M[ResultWithEntity[This, ID, E, M]] = delete(entity.identity)
 
 }
 

--- a/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/async/AsyncEntityWriter.scala
+++ b/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/async/AsyncEntityWriter.scala
@@ -26,23 +26,23 @@ trait AsyncEntityWriter[ID <: Identity[_], E <: Entity[ID]]
    *
    * @param entity 保存する対象のエンティティ
    * @return Success:
-   *         非同期リポジトリ
+   *         リポジトリインスタンスと保存されたエンティティ
    *         Failure:
    *         RepositoryException リポジトリにアクセスできなかった場合
    *         Futureが失敗した場合の例外
    */
-  def store(entity: E): Future[ResultWithEntity[This, ID, E, Future]]
+  def store(entity: E): Future[AsyncResultWithEntity[This, ID, E]]
 
   /**
    * 識別子を指定してエンティティを削除する。
    *
    * @param identity 識別子
    * @return Success:
-   *         非同期リポジトリ
+   *         リポジトリインスタンスと削除されたエンティティ
    *         Failure:
    *         RepositoryException リポジトリにアクセスできなかった場合
    *         Futureが失敗した場合の例外
    */
-  def delete(identity: ID): Future[This]
+  def delete(identity: ID): Future[AsyncResultWithEntity[This, ID, E]]
 
 }

--- a/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/forwarding/async/ForwardingAsyncEntityWriter.scala
+++ b/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/forwarding/async/ForwardingAsyncEntityWriter.scala
@@ -1,6 +1,5 @@
 package org.sisioh.dddbase.core.lifecycle.forwarding.async
 
-import org.sisioh.dddbase.core.lifecycle.ResultWithEntity
 import org.sisioh.dddbase.core.lifecycle.async.{AsyncResultWithEntity, AsyncEntityWriter}
 import org.sisioh.dddbase.core.model.{Entity, Identity}
 import scala.concurrent.Future
@@ -29,7 +28,7 @@ trait ForwardingAsyncEntityWriter[ID <: Identity[_], E <: Entity[ID]]
    */
   protected def createInstance(state: Future[(Delegate#This, Option[E])]): Future[(This, Option[E])]
 
-  def store(entity: E): Future[ResultWithEntity[This, ID, E, Future]] = {
+  def store(entity: E): Future[AsyncResultWithEntity[This, ID, E]] = {
     val state = delegate.store(entity).map {
       result =>
         (result.result.asInstanceOf[Delegate#This], Some(result.entity))
@@ -41,15 +40,15 @@ trait ForwardingAsyncEntityWriter[ID <: Identity[_], E <: Entity[ID]]
     }
   }
 
-  def delete(identity: ID): Future[This] = {
+  def delete(identity: ID): Future[AsyncResultWithEntity[This, ID, E]] = {
     val state = delegate.delete(identity).map {
       result =>
-        (result.asInstanceOf[Delegate#This], None)
+        (result.result.asInstanceOf[Delegate#This], Some(result.entity))
     }
     val instance = createInstance(state)
     instance.map {
       e =>
-        e._1
+        AsyncResultWithEntity(e._1, e._2.get)
     }
   }
 

--- a/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/forwarding/async/wrapped/ForwardingAsyncWrappedEntityWriter.scala
+++ b/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/forwarding/async/wrapped/ForwardingAsyncWrappedEntityWriter.scala
@@ -18,16 +18,16 @@ trait ForwardingAsyncWrappedEntityWriter[ID <: Identity[_], E <: Entity[ID]]
 
   protected def createInstance(state: (Delegate#This, Option[E])): (This, Option[E])
 
-  def store(entity: E): Future[ResultWithEntity[This, ID, E, Future]] = future {
+  def store(entity: E): Future[AsyncResultWithEntity[This, ID, E]] = future {
     val resultWithEntity = delegate.store(entity).get
     val result = createInstance((resultWithEntity.result.asInstanceOf[Delegate#This], Some(resultWithEntity.entity)))
     AsyncResultWithEntity[This, ID, E](result._1.asInstanceOf[This], result._2.get)
   }
 
-  def delete(identity: ID): Future[This] = future {
-    val resultTry = delegate.delete(identity).get
-    val result = createInstance(resultTry.asInstanceOf[Delegate#This], None)
-    result._1
+  def delete(identity: ID): Future[AsyncResultWithEntity[This,ID,E]] = future {
+    val resultWithEntity = delegate.delete(identity).get
+    val result = createInstance((resultWithEntity.result.asInstanceOf[Delegate#This], Some(resultWithEntity.entity)))
+    AsyncResultWithEntity[This, ID, E](result._1.asInstanceOf[This], result._2.get)
   }
 
 }

--- a/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/forwarding/sync/ForwardingSyncEntityWriter.scala
+++ b/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/forwarding/sync/ForwardingSyncEntityWriter.scala
@@ -1,6 +1,5 @@
 package org.sisioh.dddbase.core.lifecycle.forwarding.sync
 
-import org.sisioh.dddbase.core.lifecycle.ResultWithEntity
 import org.sisioh.dddbase.core.lifecycle.sync.{SyncEntityWriter, SyncResultWithEntity}
 import org.sisioh.dddbase.core.model.{Entity, Identity}
 import scala.util.Try
@@ -31,7 +30,7 @@ trait ForwardingSyncEntityWriter[ID <: Identity[_], E <: Entity[ID]]
    */
   protected def createInstance(state: Try[(Delegate#This, Option[E])]): Try[(This, Option[E])]
 
-  def store(entity: E): Try[ResultWithEntity[This, ID, E, Try]] = {
+  def store(entity: E): Try[SyncResultWithEntity[This, ID, E]] = {
     createInstance(
       delegate.store(entity).map {
         e =>
@@ -40,13 +39,13 @@ trait ForwardingSyncEntityWriter[ID <: Identity[_], E <: Entity[ID]]
     ).map(e => SyncResultWithEntity(e._1, e._2.get))
   }
 
-  def delete(identity: ID): Try[This] = {
+  def delete(identity: ID): Try[SyncResultWithEntity[This, ID, E]] = {
     createInstance(
       delegate.delete(identity).map {
         e =>
-          (e.asInstanceOf[Delegate#This], None)
+          (e.result.asInstanceOf[Delegate#This], Some(e.entity))
       }
-    ).map(e => e._1)
+    ).map(e => SyncResultWithEntity(e._1, e._2.get))
   }
 
 }

--- a/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/memory/async/AsyncRepositoryOnMemorySupport.scala
+++ b/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/memory/async/AsyncRepositoryOnMemorySupport.scala
@@ -15,7 +15,6 @@
  */
 package org.sisioh.dddbase.core.lifecycle.memory.async
 
-import org.sisioh.dddbase.core.lifecycle.ResultWithEntity
 import org.sisioh.dddbase.core.lifecycle.async.AsyncResultWithEntity
 import org.sisioh.dddbase.core.lifecycle.memory.sync.SyncRepositoryOnMemory
 import org.sisioh.dddbase.core.model.{Identity, EntityCloneable, Entity}
@@ -67,18 +66,18 @@ E <: Entity[ID] with EntityCloneable[ID, E]]
     core.contains(identifier).get
   }
 
-  def store(entity: E): Future[ResultWithEntity[This, ID, E, Future]] = future {
+  def store(entity: E): Future[AsyncResultWithEntity[This, ID, E]] = future {
     val result = core.store(entity).get
     val t = (result.result.asInstanceOf[SR], Some(result.entity))
     val instance = createInstance(t)
     AsyncResultWithEntity(instance._1, instance._2.get)
   }
 
-  def delete(identity: ID): Future[This] = future {
+  def delete(identity: ID): Future[AsyncResultWithEntity[This, ID, E]] = future {
     val result = core.delete(identity).get
-    val t = (result.asInstanceOf[SR], None)
+    val t = (result.result.asInstanceOf[SR], Some(result.entity))
     val instance = createInstance(t)
-    instance._1
+    AsyncResultWithEntity(instance._1, instance._2.get)
   }
 
 }

--- a/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/memory/mutable/sync/SyncRepositoryOnMemorySupport.scala
+++ b/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/memory/mutable/sync/SyncRepositoryOnMemorySupport.scala
@@ -48,19 +48,18 @@ E <: Entity[ID] with EntityCloneable[ID, E] with Ordered[E]]
 
   override def hashCode = 31 * core.##
 
-  def store(entity: E): Try[ResultWithEntity[This, ID, E, Try]] = {
+  def store(entity: E): Try[SyncResultWithEntity[This, ID, E]] = {
     core.store(entity).map {
-      result =>
-        core = result.result.asInstanceOf[SyncRepositoryOnMemory[ID, E]]
-        SyncResultWithEntity(this.asInstanceOf[This], result.entity)
+      resultWithEntity =>
+        core = resultWithEntity.result.asInstanceOf[SyncRepositoryOnMemory[ID, E]]
+        SyncResultWithEntity(this.asInstanceOf[This], resultWithEntity.entity)
     }
   }
 
-  def delete(identity: ID): Try[This] = {
+  def delete(identity: ID): Try[SyncResultWithEntity[This, ID, E]] = {
     core.delete(identity).map {
       result =>
-        core = result.asInstanceOf[SyncRepositoryOnMemory[ID, E]]
-        this.asInstanceOf[This]
+        SyncResultWithEntity(this.asInstanceOf[This], result.entity)
     }
   }
 

--- a/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/sync/SyncEntityWriter.scala
+++ b/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/sync/SyncEntityWriter.scala
@@ -38,21 +38,21 @@ trait SyncEntityWriter[ID <: Identity[_], E <: Entity[ID]]
    *
    * @param entity 保存する対象のエンティティ
    * @return Success:
-   *         リポジトリインスタンス
+   *         リポジトリインスタンスと保存したエンティティ
    *         Failure
    *         RepositoryExceptionは、リポジトリにアクセスできなかった場合。
    */
-  def store(entity: E): Try[ResultWithEntity[This, ID, E, Try]]
+  def store(entity: E): Try[SyncResultWithEntity[This, ID, E]]
 
   /**
    * 指定した識別子のエンティティを削除する。
    *
    * @param identity 識別子
    * @return Success:
-   *         リポジトリインスタンス
+   *         リポジトリインスタンスと削除されたエンティティ
    *         Failure:
    *         RepositoryExceptionは、リポジトリにアクセスできなかった場合。
    */
-  def delete(identity: ID): Try[This]
+  def delete(identity: ID): Try[SyncResultWithEntity[This, ID, E]]
 
 }

--- a/scala-dddbase-core/src/test/scala/org/sisioh/dddbase/core/lifecycle/forwarding/async/ForwardingAsyncRepositorySpec.scala
+++ b/scala-dddbase-core/src/test/scala/org/sisioh/dddbase/core/lifecycle/forwarding/async/ForwardingAsyncRepositorySpec.scala
@@ -51,8 +51,9 @@ class ForwardingAsyncRepositorySpec extends Specification with Mockito {
       val entity = spy(new EntityImpl(id))
       repository(entity.identity) = entity
       val future = repository.store(entity)
-      Await.ready(future, Duration.Inf)
+      val resultWithEntity = Await.result(future, Duration.Inf)
       there was atLeastOne(entity).identity
+      (resultWithEntity.result ne repository) must beTrue
       val future2 = future.flatMap {
         r =>
           val tr = new TestRepForwardingRepositoryImpl(r.result)
@@ -64,8 +65,9 @@ class ForwardingAsyncRepositorySpec extends Specification with Mockito {
       val repository = new GenericAsyncRepositoryOnMemory[Identity[UUID], EntityImpl]()
       val entity = spy(new EntityImpl(id))
       val future = repository.store(entity)
-      Await.ready(future, Duration.Inf)
+      val resultWithEntity = Await.result(future, Duration.Inf)
       there was atLeastOne(entity).identity
+      (resultWithEntity.result ne repository) must beTrue
       val future2 = future.flatMap {
         r =>
           val tr = new TestRepForwardingRepositoryImpl(r.result)
@@ -77,8 +79,9 @@ class ForwardingAsyncRepositorySpec extends Specification with Mockito {
       val repository = new GenericAsyncRepositoryOnMemory[Identity[UUID], EntityImpl]()
       val entity = spy(new EntityImpl(id))
       val future = repository.store(entity)
-      Await.ready(future, Duration.Inf)
+      val resultWithEntity = Await.result(future, Duration.Inf)
       there was atLeastOne(entity).identity
+      (resultWithEntity.result ne repository) must beTrue
       val future2 = future.flatMap {
         r =>
           val tr = new TestRepForwardingRepositoryImpl(r.result)

--- a/scala-dddbase-core/src/test/scala/org/sisioh/dddbase/core/lifecycle/memory/async/GenericAsyncRepositoryOnMemorySpec.scala
+++ b/scala-dddbase-core/src/test/scala/org/sisioh/dddbase/core/lifecycle/memory/async/GenericAsyncRepositoryOnMemorySpec.scala
@@ -8,6 +8,7 @@ import org.sisioh.dddbase.core.model.{EmptyIdentity, Identity, EntityCloneable, 
 import org.specs2.mock.Mockito
 import org.specs2.mutable._
 import scala.concurrent.ExecutionContext.Implicits.global
+import org.sisioh.dddbase.core.lifecycle.async.AsyncResultWithEntity
 
 class GenericAsyncRepositoryOnMemorySpec extends Specification with Mockito {
 
@@ -75,10 +76,10 @@ class GenericAsyncRepositoryOnMemorySpec extends Specification with Mockito {
       val repository = new GenericAsyncRepositoryOnMemory[Identity[UUID], EntityImpl]()
       val entity = spy(new EntityImpl(id))
       val future = repository.store(entity).flatMap {
-        asyncRepos =>
-          asyncRepos.result.delete(id).flatMap {
-            asyncRepos =>
-              asyncRepos.contains(id)
+        case AsyncResultWithEntity(repos,_) =>
+          repos.delete(id).flatMap {
+            case AsyncResultWithEntity(repos,_) =>
+              repos.contains(id)
           }
       }
       Await.ready(future, Duration.Inf)

--- a/scala-dddbase-core/src/test/scala/org/sisioh/dddbase/core/lifecycle/memory/mutable/async/TestAsyncRepository.scala
+++ b/scala-dddbase-core/src/test/scala/org/sisioh/dddbase/core/lifecycle/memory/mutable/async/TestAsyncRepository.scala
@@ -6,4 +6,5 @@ import org.sisioh.dddbase.core.model.Identity
 
 trait TestAsyncRepository
   extends AsyncRepository[Identity[UUID], TestEntity] {
+
 }

--- a/scala-dddbase-core/src/test/scala/org/sisioh/dddbase/core/lifecycle/memory/mutable/sync/GenericSyncRepositoryOnMemorySpec.scala
+++ b/scala-dddbase-core/src/test/scala/org/sisioh/dddbase/core/lifecycle/memory/mutable/sync/GenericSyncRepositoryOnMemorySpec.scala
@@ -68,7 +68,9 @@ class GenericSyncRepositoryOnMemorySpec extends Specification with Mockito {
       val repos = repository.store(entity)
       there was atLeastOne(entity).identity
       repository.resolve(id).get must_== entity
-      repos.flatMap(_.result.delete(id)).get must_!= repos
+      val resultWithEntity = repos.flatMap(_.result.delete(id)).get
+      resultWithEntity.result must_!= repos
+      resultWithEntity.entity must_== entity
     }
     "fail to resolve a entity by a non-existent identity" in {
       val repository = new GenericSyncRepositoryOnMemory[Identity[UUID], EntityImpl]()

--- a/scala-dddbase-core/src/test/scala/org/sisioh/dddbase/core/lifecycle/memory/sync/GenericSyncRepositoryOnMemorySpec.scala
+++ b/scala-dddbase-core/src/test/scala/org/sisioh/dddbase/core/lifecycle/memory/sync/GenericSyncRepositoryOnMemorySpec.scala
@@ -2,8 +2,6 @@ package org.sisioh.dddbase.core.lifecycle.memory.sync
 
 import java.util.UUID
 import org.sisioh.dddbase.core.lifecycle.EntityNotFoundException
-import org.sisioh.dddbase.core.lifecycle.EntityNotFoundException
-import org.sisioh.dddbase.core.lifecycle.memory.sync._
 import org.sisioh.dddbase.core.model.{EmptyIdentity, Identity, EntityCloneable, Entity}
 import org.specs2.mock.Mockito
 import org.specs2.mutable._
@@ -25,10 +23,11 @@ class GenericSyncRepositoryOnMemorySpec extends Specification with Mockito {
     "have stored enitty with empty identity" in {
       val repository = new GenericSyncRepositoryOnMemory[Identity[UUID], EntityImpl]()
       val entity = spy(new EntityImpl(EmptyIdentity))
-      val repos = repository.store(entity)
+      val resultWithEntity = repository.store(entity)
       there was atLeastOne(entity).identity
       repository.resolve(id).isFailure must_== true
-      repos.flatMap(_.result.contains(entity)).getOrElse(false) must_== true
+      resultWithEntity.flatMap(_.result.contains(entity)).getOrElse(false) must_== true
+      (resultWithEntity.get.result ne repository) must beTrue
     }
     "have stored entity" in {
       val repository = new GenericSyncRepositoryOnMemory[Identity[UUID], EntityImpl]()
@@ -67,10 +66,12 @@ class GenericSyncRepositoryOnMemorySpec extends Specification with Mockito {
     "delete a entity by using identity" in {
       val repository = new GenericSyncRepositoryOnMemory[Identity[UUID], EntityImpl]()
       val entity = spy(new EntityImpl(id))
-      val repos = repository.store(entity)
+      val resultWithEntity = repository.store(entity)
       there was atLeastOne(entity).identity
       repository.resolve(id).isFailure must_== true
-      repos.flatMap(_.result.delete(id)).get must_!= repos
+      val resultWithEntity2 = resultWithEntity.flatMap(_.result.delete(id)).get
+      (resultWithEntity2.result ne repository) must beTrue
+      resultWithEntity2.entity must_== entity
     }
     "fail to resolve a entity by a non-existent identity" in {
       val repository = new GenericSyncRepositoryOnMemory[Identity[UUID], EntityImpl]()

--- a/scala-dddbase-event/src/main/scala/org/sisioh/dddbase/event/async/AsyncDomainEventPublisher.scala
+++ b/scala-dddbase-event/src/main/scala/org/sisioh/dddbase/event/async/AsyncDomainEventPublisher.scala
@@ -1,0 +1,7 @@
+package org.sisioh.dddbase.event.async
+
+import org.sisioh.dddbase.event.{DomainEventPublisher, DomainEvent}
+import scala.concurrent.Future
+
+trait AsyncDomainEventPublisher[A <: DomainEvent[_], R]
+  extends DomainEventPublisher[A, Future, R]

--- a/scala-dddbase-event/src/main/scala/org/sisioh/dddbase/event/async/GenericAsyncDomainEventPublisher.scala
+++ b/scala-dddbase-event/src/main/scala/org/sisioh/dddbase/event/async/GenericAsyncDomainEventPublisher.scala
@@ -12,7 +12,8 @@ import scala.concurrent.Future
  */
 case class GenericAsyncDomainEventPublisher[A <: DomainEvent[_], R]
 (subscribers: Seq[AsyncDomainEventSubscriber[A, R]] = Seq.empty[AsyncDomainEventSubscriber[A, R]])
-  extends DomainEventPublisherSupport[A, Future, R] {
+  extends AsyncDomainEventPublisher[A, R]
+  with DomainEventPublisherSupport[A, Future, R] {
 
   type This = GenericAsyncDomainEventPublisher[A, R]
 

--- a/scala-dddbase-event/src/main/scala/org/sisioh/dddbase/event/lifecycle/AsyncRepositoryEventSupport.scala
+++ b/scala-dddbase-event/src/main/scala/org/sisioh/dddbase/event/lifecycle/AsyncRepositoryEventSupport.scala
@@ -6,21 +6,44 @@ import org.sisioh.dddbase.event.async.AsyncDomainEventSubscriber
 import org.sisioh.dddbase.event.mutable.async.GenericAsyncDomainEventPublisher
 import scala.concurrent.Future
 
+/**
+ * 非同期型リポジトリにイベント管理機能を追加するためのトレイト。
+ *
+ * @tparam ID エンティティの識別子の型
+ * @tparam E エンティティの型
+ */
 trait AsyncRepositoryEventSupport[ID <: Identity[_], E <: Entity[ID]]
   extends AsyncRepository[ID, E] {
 
   private val eventPublisher = GenericAsyncDomainEventPublisher[EntityIOEvent[ID, E]]()
 
+  /**
+   * [[org.sisioh.dddbase.event.async.AsyncDomainEventSubscriber]]を登録する。
+   *
+   * @param subscriber [[org.sisioh.dddbase.event.async.AsyncDomainEventSubscriber]]
+   */
   def subscribe(subscriber: AsyncDomainEventSubscriber[EntityIOEvent[ID, E], Unit]): This = {
     eventPublisher.subscribe(subscriber)
     this.asInstanceOf[This]
   }
 
+  /**
+   * [[org.sisioh.dddbase.event.async.AsyncDomainEventPublisher]]を削除する。
+   *
+   * @param subscriber [[org.sisioh.dddbase.event.async.AsyncDomainEventPublisher]]
+   */
   def unsubscribe(subscriber: AsyncDomainEventSubscriber[EntityIOEvent[ID, E], Unit]): This = {
     eventPublisher.unsubscribe(subscriber)
     this.asInstanceOf[This]
   }
 
+  /**
+   * [[org.sisioh.dddbase.event.lifecycle.EntityIOEvent]]を生成する。
+   *
+   * @param entity エンティティ
+   * @param eventType イベントの種類
+   * @return [[org.sisioh.dddbase.event.lifecycle.EntityIOEvent]]
+   */
   protected def createEntityIOEvent(entity: E, eventType: EventType.Value): EntityIOEvent[ID, E]
 
   abstract override def store(entity: E): Future[AsyncResultWithEntity[This, ID, E]] = {

--- a/scala-dddbase-event/src/main/scala/org/sisioh/dddbase/event/lifecycle/AsyncRepositoryEventSupport.scala
+++ b/scala-dddbase-event/src/main/scala/org/sisioh/dddbase/event/lifecycle/AsyncRepositoryEventSupport.scala
@@ -1,0 +1,46 @@
+package org.sisioh.dddbase.event.lifecycle
+
+import org.sisioh.dddbase.core.lifecycle.async.{AsyncResultWithEntity, AsyncRepository}
+import org.sisioh.dddbase.core.model.{Entity, Identity}
+import org.sisioh.dddbase.event.async.AsyncDomainEventSubscriber
+import org.sisioh.dddbase.event.mutable.async.GenericAsyncDomainEventPublisher
+import scala.concurrent.Future
+
+trait AsyncRepositoryEventSupport[ID <: Identity[_], E <: Entity[ID]]
+  extends AsyncRepository[ID, E] {
+
+  private val eventPublisher = GenericAsyncDomainEventPublisher[EntityIOEvent[ID, E]]()
+
+  def subscribe(subscriber: AsyncDomainEventSubscriber[EntityIOEvent[ID, E], Unit]): This = {
+    eventPublisher.subscribe(subscriber)
+    this.asInstanceOf[This]
+  }
+
+  def unsubscribe(subscriber: AsyncDomainEventSubscriber[EntityIOEvent[ID, E], Unit]): This = {
+    eventPublisher.unsubscribe(subscriber)
+    this.asInstanceOf[This]
+  }
+
+  protected def createEntityIOEvent(entity: E, eventType: EventType.Value): EntityIOEvent[ID, E]
+
+  abstract override def store(entity: E): Future[AsyncResultWithEntity[This, ID, E]] = {
+    val result = super.store(entity)
+    result onSuccess {
+      case resultWithEntity =>
+        val event = createEntityIOEvent(resultWithEntity.entity, EventType.Store)
+        eventPublisher.publish(event)
+    }
+    result.asInstanceOf[Future[AsyncResultWithEntity[This, ID, E]]]
+  }
+
+  abstract override def delete(identity: ID): Future[AsyncResultWithEntity[This, ID, E]] = {
+    val result = super.delete(identity)
+    result onSuccess {
+      case resultWithEntity =>
+        val event = createEntityIOEvent(resultWithEntity.entity, EventType.Delete)
+        eventPublisher.publish(event)
+    }
+    result.asInstanceOf[Future[AsyncResultWithEntity[This, ID, E]]]
+  }
+
+}

--- a/scala-dddbase-event/src/main/scala/org/sisioh/dddbase/event/lifecycle/EventType.scala
+++ b/scala-dddbase-event/src/main/scala/org/sisioh/dddbase/event/lifecycle/EventType.scala
@@ -6,14 +6,9 @@ package org.sisioh.dddbase.event.lifecycle
 object EventType extends Enumeration {
 
   /**
-   * 参照
-   */
-  val Resolve,
-
-  /**
    * 保存　
    */
-  Store,
+  val Store,
 
 
   /**

--- a/scala-dddbase-event/src/main/scala/org/sisioh/dddbase/event/lifecycle/SyncRepositoryEventSupport.scala
+++ b/scala-dddbase-event/src/main/scala/org/sisioh/dddbase/event/lifecycle/SyncRepositoryEventSupport.scala
@@ -1,0 +1,44 @@
+package org.sisioh.dddbase.event.lifecycle
+
+import org.sisioh.dddbase.core.lifecycle.sync.{SyncResultWithEntity, SyncRepository}
+import org.sisioh.dddbase.core.model.{Entity, Identity}
+import org.sisioh.dddbase.event.sync.SyncDomainEventSubscriber
+import org.sisioh.dddbase.event.mutable.sync.GenericSyncDomainEventPublisher
+import scala.util.Try
+
+trait SyncRepositoryEventSupport[ID <: Identity[_], E <: Entity[ID]]
+  extends SyncRepository[ID, E] {
+
+  private val eventPublisher = GenericSyncDomainEventPublisher[EntityIOEvent[ID, E]]()
+
+  def subscribe(subscriber: SyncDomainEventSubscriber[EntityIOEvent[ID, E], Unit]): This = {
+    eventPublisher.subscribe(subscriber)
+    this.asInstanceOf[This]
+  }
+
+  def unsubscribe(subscriber: SyncDomainEventSubscriber[EntityIOEvent[ID, E], Unit]): This = {
+    eventPublisher.unsubscribe(subscriber)
+    this.asInstanceOf[This]
+  }
+
+  protected def createEntityIOEvent(entity: E, eventType: EventType.Value): EntityIOEvent[ID, E]
+
+  abstract override def store(entity: E): Try[SyncResultWithEntity[This, ID, E]] = {
+    val result = super.store(entity).map{
+      resultWithEntity =>
+        val event = createEntityIOEvent(resultWithEntity.entity, EventType.Store)
+        eventPublisher.publish(event)
+    }
+    result.asInstanceOf[Try[SyncResultWithEntity[This, ID, E]]]
+  }
+
+  abstract override def delete(identity: ID): Try[SyncResultWithEntity[This, ID, E]] = {
+    val result = super.delete(identity).map{
+      resultWithEntity =>
+        val event = createEntityIOEvent(resultWithEntity.entity, EventType.Delete)
+        eventPublisher.publish(event)
+    }
+    result.asInstanceOf[Try[SyncResultWithEntity[This, ID, E]]]
+  }
+
+}

--- a/scala-dddbase-event/src/main/scala/org/sisioh/dddbase/event/lifecycle/SyncRepositoryEventSupport.scala
+++ b/scala-dddbase-event/src/main/scala/org/sisioh/dddbase/event/lifecycle/SyncRepositoryEventSupport.scala
@@ -6,21 +6,44 @@ import org.sisioh.dddbase.event.sync.SyncDomainEventSubscriber
 import org.sisioh.dddbase.event.mutable.sync.GenericSyncDomainEventPublisher
 import scala.util.Try
 
+/**
+ * 同期型リポジトリにイベント管理機能を追加するためのトレイト。
+ *
+ * @tparam ID エンティティの識別子の型
+ * @tparam E エンティティの型
+ */
 trait SyncRepositoryEventSupport[ID <: Identity[_], E <: Entity[ID]]
   extends SyncRepository[ID, E] {
 
   private val eventPublisher = GenericSyncDomainEventPublisher[EntityIOEvent[ID, E]]()
 
+  /**
+   * [[org.sisioh.dddbase.event.sync.SyncDomainEventSubscriber]]を登録する。
+   *
+   * @param subscriber [[org.sisioh.dddbase.event.sync.SyncDomainEventSubscriber]]
+   */
   def subscribe(subscriber: SyncDomainEventSubscriber[EntityIOEvent[ID, E], Unit]): This = {
     eventPublisher.subscribe(subscriber)
     this.asInstanceOf[This]
   }
 
+  /**
+   * [[org.sisioh.dddbase.event.sync.SyncDomainEventPublisher]]を削除する。
+   *
+   * @param subscriber [[org.sisioh.dddbase.event.sync.SyncDomainEventPublisher]]
+   */
   def unsubscribe(subscriber: SyncDomainEventSubscriber[EntityIOEvent[ID, E], Unit]): This = {
     eventPublisher.unsubscribe(subscriber)
     this.asInstanceOf[This]
   }
 
+  /**
+   * [[org.sisioh.dddbase.event.lifecycle.EntityIOEvent]]を生成する。
+   *
+   * @param entity エンティティ
+   * @param eventType イベントの種類
+   * @return [[org.sisioh.dddbase.event.lifecycle.EntityIOEvent]]
+   */
   protected def createEntityIOEvent(entity: E, eventType: EventType.Value): EntityIOEvent[ID, E]
 
   abstract override def store(entity: E): Try[SyncResultWithEntity[This, ID, E]] = {

--- a/scala-dddbase-event/src/main/scala/org/sisioh/dddbase/event/sync/GenericSyncDomainEventPublisher.scala
+++ b/scala-dddbase-event/src/main/scala/org/sisioh/dddbase/event/sync/GenericSyncDomainEventPublisher.scala
@@ -1,6 +1,6 @@
 package org.sisioh.dddbase.event.sync
 
-import org.sisioh.dddbase.event.{DomainEventPublisherSupport, DomainEventSubscriber, DomainEvent}
+import org.sisioh.dddbase.event.{DomainEventPublisherSupport, DomainEvent}
 import scala.util._
 
 /**
@@ -12,7 +12,8 @@ import scala.util._
  */
 case class GenericSyncDomainEventPublisher[A <: DomainEvent[_], R]
 (subscribers: Seq[SyncDomainEventSubscriber[A, R]] = Seq.empty[SyncDomainEventSubscriber[A, R]])
-  extends DomainEventPublisherSupport[A, Try, R] {
+  extends SyncDomainEventPublisher[A, R]
+  with DomainEventPublisherSupport[A, Try, R] {
 
   type This = GenericSyncDomainEventPublisher[A, R]
 

--- a/scala-dddbase-event/src/main/scala/org/sisioh/dddbase/event/sync/SyncDomainEventPublisher.scala
+++ b/scala-dddbase-event/src/main/scala/org/sisioh/dddbase/event/sync/SyncDomainEventPublisher.scala
@@ -1,0 +1,7 @@
+package org.sisioh.dddbase.event.sync
+
+import org.sisioh.dddbase.event.{DomainEventPublisher, DomainEvent}
+import scala.util.Try
+
+trait SyncDomainEventPublisher[A <: DomainEvent[_], R]
+  extends DomainEventPublisher[A, Try, R]

--- a/scala-dddbase-event/src/test/scala/org/sisioh/dddbase/event/lifecycle/AsyncRepositoryEventSupportSpec.scala
+++ b/scala-dddbase-event/src/test/scala/org/sisioh/dddbase/event/lifecycle/AsyncRepositoryEventSupportSpec.scala
@@ -1,0 +1,49 @@
+package org.sisioh.dddbase.event.lifecycle
+
+import org.specs2.mutable.Specification
+import org.sisioh.dddbase.core.model.{Entity, EntityCloneable, Identity}
+import java.util.UUID
+import org.sisioh.dddbase.core.lifecycle.memory.mutable.async.GenericAsyncRepositoryOnMemory
+import org.sisioh.dddbase.event.async.AsyncDomainEventSubscriber
+import scala.concurrent._
+import scala.concurrent.duration.Duration
+import ExecutionContext.Implicits.global
+
+class AsyncRepositoryEventSupportSpec extends Specification {
+
+  class EntityImpl(val identity: Identity[UUID]) extends Entity[Identity[UUID]]
+  with EntityCloneable[Identity[UUID], EntityImpl]
+  with Ordered[EntityImpl] {
+    def compare(that: EntityImpl): Int = {
+      identity.value.compareTo(that.identity.value)
+    }
+  }
+
+  class TestRepository extends GenericAsyncRepositoryOnMemory[Identity[UUID], EntityImpl]
+  with AsyncRepositoryEventSupport[Identity[UUID], EntityImpl] {
+    protected def createEntityIOEvent(entity: EntityImpl, eventType: EventType.Value):
+    EntityIOEvent[Identity[UUID], EntityImpl] = new EntityIOEvent[Identity[UUID], EntityImpl](Identity(UUID.randomUUID()), entity, eventType)
+  }
+
+  "event subscriber" should {
+    "receive entity io event" in {
+      var result: Boolean = false
+      var resultEntity: EntityImpl = null
+      var resultEventType: EventType.Value = null
+      val repos = new TestRepository()
+      val entity = new EntityImpl(Identity(UUID.randomUUID()))
+      repos.subscribe(new AsyncDomainEventSubscriber[EntityIOEvent[Identity[UUID], EntityImpl], Unit] {
+        def handleEvent(event: EntityIOEvent[Identity[UUID], EntityImpl]): Future[Unit] = future {
+          result = true
+          resultEntity = event.entity
+          resultEventType = event.eventType
+          ()
+        }
+      })
+      Await.result(repos.store(entity), Duration.Inf)
+      result must beTrue
+      resultEntity must_== entity
+      resultEventType must_== EventType.Store
+    }
+  }
+}

--- a/scala-dddbase-event/src/test/scala/org/sisioh/dddbase/event/lifecycle/SyncRepositoryEventSupportSpec.scala
+++ b/scala-dddbase-event/src/test/scala/org/sisioh/dddbase/event/lifecycle/SyncRepositoryEventSupportSpec.scala
@@ -1,0 +1,48 @@
+package org.sisioh.dddbase.event.lifecycle
+
+import org.specs2.mutable.Specification
+import org.sisioh.dddbase.core.lifecycle.memory.mutable.sync.GenericSyncRepositoryOnMemory
+import org.sisioh.dddbase.core.model.{EntityCloneable, Entity, Identity}
+import java.util.UUID
+import org.sisioh.dddbase.event.sync.SyncDomainEventSubscriber
+import scala.util.{Success, Try}
+
+class SyncRepositoryEventSupportSpec extends Specification {
+
+  class EntityImpl(val identity: Identity[UUID]) extends Entity[Identity[UUID]]
+    with EntityCloneable[Identity[UUID], EntityImpl]
+    with Ordered[EntityImpl] {
+    def compare(that: EntityImpl): Int = {
+      identity.value.compareTo(that.identity.value)
+    }
+  }
+
+  class TestRepository extends GenericSyncRepositoryOnMemory[Identity[UUID], EntityImpl]
+  with SyncRepositoryEventSupport[Identity[UUID], EntityImpl] {
+    protected def createEntityIOEvent(entity: EntityImpl, eventType: EventType.Value):
+    EntityIOEvent[Identity[UUID], EntityImpl] = new EntityIOEvent[Identity[UUID], EntityImpl](Identity(UUID.randomUUID()), entity, eventType)
+  }
+
+  "event subscriber" should {
+    "receive entity io event" in {
+      var result: Boolean = false
+      var resultEntity: EntityImpl = null
+      var resultEventType: EventType.Value = null
+      val repos = new TestRepository()
+      val entity = new EntityImpl(Identity(UUID.randomUUID()))
+      repos.subscribe(new SyncDomainEventSubscriber[EntityIOEvent[Identity[UUID], EntityImpl], Unit] {
+        def handleEvent(event: EntityIOEvent[Identity[UUID], EntityImpl]): Try[Unit] = {
+          result = true
+          resultEntity = event.entity
+          resultEventType = event.eventType
+          Success(())
+        }
+      })
+      repos.store(entity)
+      result must beTrue
+      resultEntity must_== entity
+      resultEventType must_== EventType.Store
+    }
+  }
+
+}


### PR DESCRIPTION
- リポジトリの状態が変化した時に、そのイベントを別のオブジェクトが受信したいことがあります。イベントにはどのエンティティかという情報が含まれますが、deleteメソッドは削除されたエンティティがわかりません。storeメソッドと同様にResultWithEntityを返すように修正してわかるようにしました。
- また、SyncRepositoryEventSupport/AsyncRepositoryEventSupportのトレイトを実装すれば、store, deleteなどの状態変更系のメソッド操作を行った際に、DomainEventSubscriberにイベントを通知できるようになります。
