### PR TITLE
基本トレイトの作成

### DIFF
--- a/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/BaseEntityReader.scala
+++ b/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/BaseEntityReader.scala
@@ -1,0 +1,46 @@
+package org.sisioh.dddbase.core.lifecycle
+
+import org.sisioh.dddbase.core.model.{Entity, Identity}
+import scala.language.higherKinds
+
+/**
+ * [[org.sisioh.dddbase.core.model.Identity]]を用いて
+ * [[org.sisioh.dddbase.core.model.Entity]]
+ * を読み込むための責務を表す基本トレイト。
+ *
+ * @tparam ID 識別子の型
+ * @tparam E エンティティの型
+ * @tparam M モナド
+ */
+trait BaseEntityReader[ID <: Identity[_], E <: Entity[ID], M[+A]]
+  extends EntityIO {
+
+  type This <: BaseEntityReader[ID, E, M]
+
+  protected def resolve(identity: ID)(implicit ctx: EntityIOContext[M]): M[E]
+
+  /**
+   * 複数の値からエンティティを取得し、`M[Seq[E]]` に変換する。
+   *
+   * @param values 入力値の集合
+   * @param f エンティティを引き当てるための関数
+   * @param ctx [[org.sisioh.dddbase.core.lifecycle.EntityIOContext]]
+   * @tparam V 入力値の型
+   * @return M にラップされた Seq[E]
+   */
+  protected def traverse[V](values: Seq[V])(f: (V) => M[E])
+                           (implicit ctx: EntityIOContext[M]): M[Seq[E]]
+
+  protected def resolves(identities: Seq[ID])(implicit ctx: EntityIOContext[M]): M[Seq[E]]
+
+  protected def apply(identity: ID)(implicit ctx: EntityIOContext[M]): M[E]
+
+  protected def containsByIdentity(identity: ID)(implicit ctx: EntityIOContext[M]): M[Boolean]
+
+  protected def containsByIdentities(identities: Seq[ID])(implicit ctx: EntityIOContext[M]): M[Boolean]
+
+  protected def contains(entity: E)(implicit ctx: EntityIOContext[M]): M[Boolean]
+
+  protected def contains(entities: Seq[E])(implicit ctx: EntityIOContext[M]): M[Boolean]
+
+}

--- a/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/BaseEntityWriter.scala
+++ b/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/BaseEntityWriter.scala
@@ -1,18 +1,3 @@
-/*
- * Copyright 2011-2013 Sisioh Project and others. (http://www.sisioh.org/)
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
- * either express or implied. See the License for the specific language
- * governing permissions and limitations under the License.
- */
 package org.sisioh.dddbase.core.lifecycle
 
 import org.sisioh.dddbase.core.model.{Entity, Identity}
@@ -21,14 +6,16 @@ import scala.language.higherKinds
 /**
  * [[org.sisioh.dddbase.core.model.Identity]]を用いて
  * [[org.sisioh.dddbase.core.model.Entity]]
- * を書き込むための責務を表すトレイト。
+ * を書き込むための責務を表す基本トレイト。
  *
  * @tparam ID 識別子の型
  * @tparam E エンティティの型
  * @tparam M モナド
  */
-trait EntityWriter[ID <: Identity[_], E <: Entity[ID], M[+A]]
-  extends EntityIO with BaseEntityWriter[ID, E, M] {
+trait BaseEntityWriter[ID <: Identity[_], E <: Entity[ID], M[+A]]
+  extends EntityIO {
+
+  type This <: BaseEntityWriter[ID, E, M]
 
   /**
    * エンティティを保存する。
@@ -39,7 +26,7 @@ trait EntityWriter[ID <: Identity[_], E <: Entity[ID], M[+A]]
    *         Failure
    *         RepositoryExceptionは、リポジトリにアクセスできなかった場合。
    */
-  def store(entity: E)(implicit ctx: EntityIOContext[M]): M[ResultWithEntity[This, ID, E, M]]
+  protected def store(entity: E)(implicit ctx: EntityIOContext[M]): M[ResultWithEntity[This, ID, E, M]]
 
   /**
    * 複数のエンティティを保存する。
@@ -50,7 +37,7 @@ trait EntityWriter[ID <: Identity[_], E <: Entity[ID], M[+A]]
    *         Failure
    *         RepositoryExceptionは、リポジトリにアクセスできなかった場合。
    */
-  def store(entities: Seq[E])(implicit ctx: EntityIOContext[M]): M[ResultWithEntities[This, ID, E, M]]
+  protected def store(entities: Seq[E])(implicit ctx: EntityIOContext[M]): M[ResultWithEntities[This, ID, E, M]]
 
 
   /**
@@ -67,7 +54,7 @@ trait EntityWriter[ID <: Identity[_], E <: Entity[ID], M[+A]]
    *         Failure
    *         RepositoryExceptionは、リポジトリにアクセスできなかった場合。
    */
-  def update(identity: ID, entity: E)(implicit ctx: EntityIOContext[M]) = store(entity)
+  protected def update(identity: ID, entity: E)(implicit ctx: EntityIOContext[M])
 
   /**
    * 指定した識別子のエンティティを削除する。
@@ -78,7 +65,7 @@ trait EntityWriter[ID <: Identity[_], E <: Entity[ID], M[+A]]
    *         Failure:
    *         RepositoryExceptionは、リポジトリにアクセスできなかった場合。
    */
-  def deleteByIdentity(identity: ID)(implicit ctx: EntityIOContext[M]): M[ResultWithEntity[This, ID, E, M]]
+  protected def deleteByIdentity(identity: ID)(implicit ctx: EntityIOContext[M]): M[ResultWithEntity[This, ID, E, M]]
 
   /**
    * 指定した複数の識別子のエンティティを削除する。
@@ -89,7 +76,7 @@ trait EntityWriter[ID <: Identity[_], E <: Entity[ID], M[+A]]
    *         Failure:
    *         RepositoryExceptionは、リポジトリにアクセスできなかった場合。
    */
-  def deleteByIdentities(identities: Seq[ID])(implicit ctx: EntityIOContext[M]): M[ResultWithEntities[This, ID, E, M]]
+  protected def deleteByIdentities(identities: Seq[ID])(implicit ctx: EntityIOContext[M]): M[ResultWithEntities[This, ID, E, M]]
 
   /**
    * エンティティを削除する。
@@ -100,9 +87,8 @@ trait EntityWriter[ID <: Identity[_], E <: Entity[ID], M[+A]]
    *         Failure:
    *         RepositoryExceptionは、リポジトリにアクセスできなかった場合。
    */
-  def delete(entity: E)(implicit ctx: EntityIOContext[M]): M[ResultWithEntity[This, ID, E, M]] = deleteByIdentity(entity.identity)
+  protected def delete(entity: E)(implicit ctx: EntityIOContext[M]): M[ResultWithEntity[This, ID, E, M]]
 
-  def delete(entities: Seq[E])(implicit ctx: EntityIOContext[M]): M[ResultWithEntities[This, ID, E, M]] =
-    deleteByIdentities(entities.map(_.identity))
+  protected def delete(entities: Seq[E])(implicit ctx: EntityIOContext[M]): M[ResultWithEntities[This, ID, E, M]]
 
 }

--- a/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/BaseRepository.scala
+++ b/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/BaseRepository.scala
@@ -1,0 +1,23 @@
+package org.sisioh.dddbase.core.lifecycle
+
+import org.sisioh.dddbase.core.model.{Entity, Identity}
+import scala.language.higherKinds
+
+/**
+ * 基本的なリポジトリのトレイト。
+ * リポジトリとして、基本的に必要な機能を定義するトレイト。
+ *
+ * リポジトリの状態を変更するメソッドの戻り値としては、
+ * Immutableなリポジトリは新しいリポジトリインスタンスを返し、
+ * Mutableなリポジトリは同一インスタンスを返すこと、を推奨する。
+ *
+ * @tparam ID エンティティの識別子の型
+ * @tparam E エンティティの型
+ * @tparam M モナドの型
+ */
+trait BaseRepository[ID <: Identity[_], E <: Entity[ID], M[+A]]
+  extends BaseEntityReader[ID, E, M] with BaseEntityWriter[ID, E, M] {
+
+  type This <: BaseRepository[ID, E, M]
+
+}

--- a/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/EntityReader.scala
+++ b/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/EntityReader.scala
@@ -28,21 +28,9 @@ import scala.language.higherKinds
  * @tparam M モナド
  */
 trait EntityReader[ID <: Identity[_], E <: Entity[ID], M[+A]]
-  extends EntityIO {
+  extends EntityIO with BaseEntityReader[ID, E, M] {
 
   def resolve(identity: ID)(implicit ctx: EntityIOContext[M]): M[E]
-
-  /**
-   * 複数の値からエンティティを取得し、`M[Seq[E]]` に変換する。
-   *
-   * @param values 入力値の集合
-   * @param f エンティティを引き当てるための関数
-   * @param ctx [[org.sisioh.dddbase.core.lifecycle.EntityIOContext]]
-   * @tparam V 入力値の型
-   * @return M にラップされた Seq[E]
-   */
-  protected def traverse[V](values: Seq[V])(f: (V) => M[E])
-                           (implicit ctx: EntityIOContext[M]): M[Seq[E]]
 
   def resolves(identities: Seq[ID])(implicit ctx: EntityIOContext[M]): M[Seq[E]]
 
@@ -57,4 +45,3 @@ trait EntityReader[ID <: Identity[_], E <: Entity[ID], M[+A]]
   def contains(entities: Seq[E])(implicit ctx: EntityIOContext[M]): M[Boolean] = containsByIdentities(entities.map(_.identity))
 
 }
-

--- a/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/Repository.scala
+++ b/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/Repository.scala
@@ -31,9 +31,4 @@ import scala.language.higherKinds
  * @tparam M モナドの型
  */
 trait Repository[ID <: Identity[_], E <: Entity[ID], M[+A]]
-  extends EntityReader[ID, E, M] with EntityWriter[ID, E, M] {
-
-  type This <: Repository[ID, E, M]
-
-}
-
+  extends BaseRepository[ID, E, M] with EntityReader[ID, E, M] with EntityWriter[ID, E, M]

--- a/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/ResultWithEntities.scala
+++ b/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/ResultWithEntities.scala
@@ -11,7 +11,7 @@ import scala.language.higherKinds
  * @tparam E エンティティの型
  * @tparam M モナドの型
  */
-trait ResultWithEntities[+EW <: EntityWriter[ID, E, M], ID <: Identity[_], E <: Entity[ID], M[+A]]  {
+trait ResultWithEntities[+EW <: BaseEntityWriter[ID, E, M], ID <: Identity[_], E <: Entity[ID], M[+A]]  {
 
   /**
    * 結果

--- a/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/ResultWithEntity.scala
+++ b/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/ResultWithEntity.scala
@@ -15,8 +15,8 @@
  */
 package org.sisioh.dddbase.core.lifecycle
 
-import scala.language.higherKinds
 import org.sisioh.dddbase.core.model.{Identity, Entity}
+import scala.language.higherKinds
 
 /**
  * [[org.sisioh.dddbase.core.lifecycle.EntityWriter]]の新しい状態とエンティティを保持する値オブジェクト。
@@ -26,7 +26,7 @@ import org.sisioh.dddbase.core.model.{Identity, Entity}
  * @tparam E エンティティの型
  * @tparam M モナドの型
  */
-trait ResultWithEntity[+EW <: EntityWriter[ID, E, M], ID <: Identity[_], E <: Entity[ID], M[+A]] {
+trait ResultWithEntity[+EW <: BaseEntityWriter[ID, E, M], ID <: Identity[_], E <: Entity[ID], M[+A]] {
 
   /**
    * 結果
@@ -39,8 +39,3 @@ trait ResultWithEntity[+EW <: EntityWriter[ID, E, M], ID <: Identity[_], E <: En
   val entity: E
 
 }
-
-
-
-
-


### PR DESCRIPTION
先日話したように独自のEntityReader、EntityWriter、Repositoryを作成できるように構成を変更しました。
