### PR TITLE
OnMemoryリポジトリのdeleteByIdentityの修正

### DIFF
--- a/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/memory/mutable/sync/SyncRepositoryOnMemorySupport.scala
+++ b/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/memory/mutable/sync/SyncRepositoryOnMemorySupport.scala
@@ -58,8 +58,9 @@ E <: Entity[ID] with EntityCloneable[ID, E] with Ordered[E]]
 
   def deleteByIdentity(identity: ID)(implicit ctx: EntityIOContext[Try]): Try[SyncResultWithEntity[This, ID, E]] = {
     core.deleteByIdentity(identity).map {
-      result =>
-        SyncResultWithEntity(this.asInstanceOf[This], result.entity)
+      resultWithEntity =>
+        core = resultWithEntity.result.asInstanceOf[SyncRepositoryOnMemory[ID, E]]
+        SyncResultWithEntity(this.asInstanceOf[This], resultWithEntity.entity)
     }
   }
 

--- a/scala-dddbase-core/src/test/scala/org/sisioh/dddbase/core/lifecycle/memory/mutable/async/GenericAsyncRepositoryOnMemorySpec.scala
+++ b/scala-dddbase-core/src/test/scala/org/sisioh/dddbase/core/lifecycle/memory/mutable/async/GenericAsyncRepositoryOnMemorySpec.scala
@@ -65,6 +65,15 @@ class GenericAsyncRepositoryOnMemorySpec extends Specification with Mockito {
       Await.result(repository.resolve(id), Duration.Inf) must_== entity
       Await.result(repos.flatMap(_.result.deleteByIdentity(id)), Duration.Inf) must_!= repos
     }
+    "contains a entity by using identity" in {
+      val repository = new GenericAsyncRepositoryOnMemory[Identity[UUID], EntityImpl]()
+      val entity = spy(new EntityImpl(id))
+      val repos = repository.store(entity)
+      Await.ready(repos, Duration.Inf)
+      Await.result(repository.containsByIdentity(entity.identity), Duration.Inf) must_== true
+      Await.result(repository.deleteByIdentity(entity.identity), Duration.Inf)
+      Await.result(repository.containsByIdentity(entity.identity), Duration.Inf) must_== false
+    }
     "fail to resolve a entity by a non-existent identity" in {
       val repository = new GenericAsyncRepositoryOnMemory[Identity[UUID], EntityImpl]()
       Await.result(repository.resolve(id).recover {


### PR DESCRIPTION
Entityを消せていなかった不具合の修正です。
テストも追加しました。
