### PR TITLE
fix deleteByIdentites in AsyncEntityWriter

### DIFF
--- a/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/async/AsyncEntityWriter.scala
+++ b/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/async/AsyncEntityWriter.scala
@@ -100,7 +100,7 @@ trait AsyncEntityWriter[ID <: Identity[_], E <: Entity[ID]]
    *         RepositoryExceptionは、リポジトリにアクセスできなかった場合。
    */
   def deleteByIdentities(identities: Seq[ID])
-                        (implicit ctx: EntityIOContext[Future]): Future[ResultWithEntities[This, ID, E, Future]] = {
+                        (implicit ctx: EntityIOContext[Future]): Future[AsyncResultWithEntities[This, ID, E]] = {
     implicit val executor = getExecutionContext(ctx)
     forEachEntities(this.asInstanceOf[This], identities.toList, ListBuffer[E]()) {
       (repository, identity) =>


### PR DESCRIPTION
AsyncEntityWriter の deleteByIdentities の返り値を変更しました。
`ResultWithEntities[This, ID, E, Future]` となっていて、継承した `AsyncResultWithEntities[This, ID, E]` になっていなかったので修正しました。
