### PR TITLE
Delegateの修正とその他の細かい修正

### DIFF
--- a/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/async/AsyncEntityWriter.scala
+++ b/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/async/AsyncEntityWriter.scala
@@ -100,7 +100,7 @@ trait AsyncEntityWriter[ID <: Identity[_], E <: Entity[ID]]
    *         RepositoryExceptionは、リポジトリにアクセスできなかった場合。
    */
   def deleteByIdentities(identities: Seq[ID])
-                        (implicit ctx: EntityIOContext[Future]): Future[ResultWithEntities[This, ID, E, Future]] = {
+                        (implicit ctx: EntityIOContext[Future]): Future[AsyncResultWithEntities[This, ID, E]] = {
     implicit val executor = getExecutionContext(ctx)
     forEachEntities(this.asInstanceOf[This], identities.toList, ListBuffer[E]()) {
       (repository, identity) =>

--- a/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/memory/async/AsyncRepositoryOnMemorySupportBySeq.scala
+++ b/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/memory/async/AsyncRepositoryOnMemorySupportBySeq.scala
@@ -1,7 +1,6 @@
 package org.sisioh.dddbase.core.lifecycle.memory.async
 
 import org.sisioh.dddbase.core.lifecycle.async._
-import org.sisioh.dddbase.core.lifecycle.sync.SyncEntityReadableByOption
 import org.sisioh.dddbase.core.model._
 import scala.concurrent._
 import org.sisioh.dddbase.core.lifecycle.memory.sync.SyncRepositoryOnMemory
@@ -17,7 +16,7 @@ trait AsyncRepositoryOnMemorySupportBySeq
 [ID <: Identity[_], E <: Entity[ID] with EntityCloneable[ID, E]]
   extends AsyncRepositoryOnMemorySupport[ID, E] with AsyncEntityReadableBySeq[ID, E] {
 
-  type Delegate <: SyncRepositoryOnMemory[ID, E] with SyncEntityReadableByOption[ID, E]
+  type Delegate <: SyncRepositoryOnMemory[ID, E]
 
   def resolveAll(implicit ctx: EntityIOContext[Future]): Future[Seq[E]] = {
     val asyncCtx = getAsyncWrappedEntityIOContext(ctx)


### PR DESCRIPTION
２箇所の修正です。
1. AsyncRepositoryOnMemorySupportBySeqのDelegateの型からOptionを除きました。
2. AsyncEntityWriter の deleteByIdentities の返り値を変更しました。これは https://github.com/sisioh/scala-dddbase/pull/20 の内容と同じです。
