### PR TITLE
change logic of delete method from deleteByIdentities to multiple delete

### DIFF
--- a/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/EntityWriter.scala
+++ b/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/EntityWriter.scala
@@ -17,7 +17,6 @@ package org.sisioh.dddbase.core.lifecycle
 
 import org.sisioh.dddbase.core.model.{Entity, Identity}
 import scala.language.higherKinds
-import scala.reflect.ClassTag
 
 /**
  * [[org.sisioh.dddbase.core.model.Identity]]を用いて
@@ -97,7 +96,7 @@ trait EntityWriter[ID <: Identity[_], E <: Entity[ID], M[+A]]
   /**
    * エンティティを削除する。
    *
-   * @param entity エンティティ
+   * @param entity 削除する対象のエンティティ
    * @return Success:
    *         リポジトリインスタンスと削除されたエンティティ
    *         Failure:
@@ -105,8 +104,16 @@ trait EntityWriter[ID <: Identity[_], E <: Entity[ID], M[+A]]
    */
   def delete(entity: E)(implicit ctx: EntityIOContext[M]): M[ResultWithEntity[This, ID, E, M]] = deleteByIdentity(entity.identity)
 
-  def delete(entities: Seq[E])(implicit ctx: EntityIOContext[M]): M[ResultWithEntities[This, ID, E, M]] =
-    deleteByIdentities(entities.map(_.identity))
+  /**
+   * 複数のエンティティを削除する。
+   *
+   * @param entities 削除する対象のエンティティ
+   * @return Success:
+   *         リポジトリインスタンスと削除されたエンティティ
+   *         Failure:
+   *         RepositoryExceptionは、リポジトリにアクセスできなかった場合。
+   */
+  def delete(entities: Seq[E])(implicit ctx: EntityIOContext[M]): M[ResultWithEntities[This, ID, E, M]]
 
 }
 

--- a/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/async/AsyncEntityWriter.scala
+++ b/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/async/AsyncEntityWriter.scala
@@ -1,6 +1,6 @@
 package org.sisioh.dddbase.core.lifecycle.async
 
-import org.sisioh.dddbase.core.lifecycle.{ResultWithEntities, EntityIOContext, EntityWriter}
+import org.sisioh.dddbase.core.lifecycle.{EntityIOContext, EntityWriter}
 import org.sisioh.dddbase.core.model.{Entity, Identity}
 import scala.concurrent._
 import scala.collection.mutable.ListBuffer
@@ -105,6 +105,24 @@ trait AsyncEntityWriter[ID <: Identity[_], E <: Entity[ID]]
     forEachEntities(this.asInstanceOf[This], identities.toList, ListBuffer[E]()) {
       (repository, identity) =>
         repository.deleteByIdentity(identity).asInstanceOf[Future[AsyncResultWithEntity[This, ID, E]]]
+    }
+  }
+
+  /**
+   * 指定した複数の識別子のエンティティを削除する。
+   *
+   * @param entities 削除する対象のエンティティ
+   * @return Success:
+   *         リポジトリインスタンスと削除されたエンティティ
+   *         Failure:
+   *         RepositoryExceptionは、リポジトリにアクセスできなかった場合。
+   */
+  def delete(entities: Seq[E])
+            (implicit ctx: EntityIOContext[Future]): Future[AsyncResultWithEntities[This, ID, E]] = {
+    implicit val executor = getExecutionContext(ctx)
+    forEachEntities(this.asInstanceOf[This], entities.toList, ListBuffer[E]()) {
+      (repository, entity) =>
+        repository.delete(entity).asInstanceOf[Future[AsyncResultWithEntity[This, ID, E]]]
     }
   }
 

--- a/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/sync/SyncEntityWriter.scala
+++ b/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/sync/SyncEntityWriter.scala
@@ -57,7 +57,7 @@ trait SyncEntityWriter[ID <: Identity[_], E <: Entity[ID]]
    *         RepositoryExceptionは、リポジトリにアクセスできなかった場合。
    */
   protected final def forEachEntities[A](tasks: Seq[A])(processor: (This, A) => Try[SyncResultWithEntity[This, ID, E]])
-                                  (implicit ctx: EntityIOContext[Try]): Try[SyncResultWithEntities[This, ID, E]] = Try {
+                                        (implicit ctx: EntityIOContext[Try]): Try[SyncResultWithEntities[This, ID, E]] = Try {
     val result = tasks.foldLeft[(This, Seq[E])]((this.asInstanceOf[This], Seq.empty[E])) {
       (resultWithEntities, task) =>
         val resultWithEntity = processor(resultWithEntities._1, task).get
@@ -106,5 +106,21 @@ trait SyncEntityWriter[ID <: Identity[_], E <: Entity[ID]]
       (repository, identity) =>
         repository.deleteByIdentity(identity).asInstanceOf[Try[SyncResultWithEntity[This, ID, E]]]
     }
+
+  /**
+   * 指定した複数の識別子のエンティティを削除する。
+   *
+   * @param entities 削除する対象のエンティティ
+   * @return Success:
+   *         リポジトリインスタンスと削除されたエンティティ
+   *         Failure:
+   *         RepositoryExceptionは、リポジトリにアクセスできなかった場合。
+   */
+  def delete(entities: Seq[E])(implicit ctx: EntityIOContext[Try]): Try[ResultWithEntities[This, ID, E, Try]] = {
+    forEachEntities(entities) {
+      (repository, entity) =>
+        repository.delete(entity).asInstanceOf[Try[SyncResultWithEntity[This, ID, E]]]
+    }
+  }
 
 }


### PR DESCRIPTION
repositoryの`delete(Seq[E])`のロジックを変更しました。
今までは、`deleteByIdentities(Seq[ID])`を呼ぶだけでしたが、`delete(E)`を複数回呼ぶように変更しました。

意図としては、`delete(Seq[E])`は`delete(E)`に依存するようにしたかったからです。
