### PR TITLE
Update Scala version to 2.11.1 and libraries to newest.

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -2,15 +2,16 @@ import sbt._
 import Keys._
 
 object DDDBaseBuild extends Build {
-  val specs2 = "org.specs2" %% "specs2" % "2.0" % "test"
-  val scalaTest = "org.scalatest" %% "scalatest" % "1.9.1" % "test"
+  val specs2 = "org.specs2" %% "specs2" % "2.3.12" % "test"
+  val scalaTest = "org.scalatest" %% "scalatest" % "2.2.0" % "test"
   val junit = "junit" % "junit" % "4.8.1" % "test"
   val mockito = "org.mockito" % "mockito-core" % "1.9.5" % "test"
 
   lazy val commonSettings = Defaults.defaultSettings ++ Seq(
     organization := "org.sisioh",
     version := "0.1.27",
-    scalaVersion := "2.10.3",
+    scalaVersion := "2.10.4",
+    crossScalaVersions := Seq("2.10.4", "2.11.1"),
     libraryDependencies ++= Seq(junit, scalaTest, mockito, scalaTest, specs2),
     scalacOptions ++= Seq("-feature", "-unchecked", "-deprecation"),
     shellPrompt := {

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.12.2
+sbt.version=0.13.5

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
-addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.4.0")
+addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.6.0")
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-pgp" % "0.8")
+addSbtPlugin("com.typesafe.sbt" % "sbt-pgp" % "0.8.3")
 
 logLevel := Level.Warn

--- a/release.sh
+++ b/release.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-sbt clean publish
+sbt +clean +publish
 rm -fr /tmp/repos
 mv ./repos /tmp
 git checkout gh-pages

--- a/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/forwarding/async/wrapped/AsyncWrappedSyncEntityReader.scala
+++ b/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/forwarding/async/wrapped/AsyncWrappedSyncEntityReader.scala
@@ -24,7 +24,7 @@ trait AsyncWrappedSyncEntityReader[ID <: Identity[_], E <: Entity[ID]]
   def resolve(identity: ID)(implicit ctx: EntityIOContext[Future]) = {
     val asyncCtx = getAsyncWrappedEntityIOContext(ctx)
     implicit val executor = asyncCtx.executor
-    future {
+    Future {
       implicit val syncCtx = asyncCtx.syncEntityIOContext
       delegate.resolve(identity).get
     }
@@ -33,7 +33,7 @@ trait AsyncWrappedSyncEntityReader[ID <: Identity[_], E <: Entity[ID]]
   def containsByIdentity(identity: ID)(implicit ctx: EntityIOContext[Future]): Future[Boolean] = {
     val asyncCtx = getAsyncWrappedEntityIOContext(ctx)
     implicit val executor = asyncCtx.executor
-    future {
+    Future {
       implicit val syncCtx = asyncCtx.syncEntityIOContext
        delegate.containsByIdentity(identity).get
     }

--- a/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/forwarding/async/wrapped/AsyncWrappedSyncEntityWriter.scala
+++ b/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/forwarding/async/wrapped/AsyncWrappedSyncEntityWriter.scala
@@ -29,7 +29,7 @@ trait AsyncWrappedSyncEntityWriter[ID <: Identity[_], E <: Entity[ID]]
   def store(entity: E)(implicit ctx: EntityIOContext[Future]): Future[AsyncResultWithEntity[This, ID, E]] = {
     val asyncCtx = getAsyncWrappedEntityIOContext(ctx)
     implicit val executor = asyncCtx.executor
-    future {
+    Future {
       implicit val syncCtx = asyncCtx.syncEntityIOContext
       val resultWithEntity = delegate.store(entity).get
       val result = createInstance((resultWithEntity.result.asInstanceOf[Delegate#This], Some(resultWithEntity.entity)))
@@ -40,7 +40,7 @@ trait AsyncWrappedSyncEntityWriter[ID <: Identity[_], E <: Entity[ID]]
   def deleteByIdentity(identity: ID)(implicit ctx: EntityIOContext[Future]): Future[AsyncResultWithEntity[This, ID, E]] = {
     val asyncCtx = getAsyncWrappedEntityIOContext(ctx)
     implicit val executor = asyncCtx.executor
-    future {
+    Future {
       implicit val syncCtx = asyncCtx.syncEntityIOContext
       val resultWithEntity = delegate.deleteByIdentity(identity).get
       val result = createInstance((resultWithEntity.result.asInstanceOf[Delegate#This], Some(resultWithEntity.entity)))

--- a/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/memory/async/AsyncRepositoryOnMemorySupportByChunk.scala
+++ b/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/memory/async/AsyncRepositoryOnMemorySupportByChunk.scala
@@ -25,7 +25,7 @@ trait AsyncRepositoryOnMemorySupportByChunk
                   (implicit ctx: EntityIOContext[Future]): Future[EntitiesChunk[ID, E]] = {
     val asyncCtx = getAsyncWrappedEntityIOContext(ctx)
     implicit val executor = asyncCtx.executor
-    future {
+    Future {
       implicit val syncCtx = asyncCtx.syncEntityIOContext
       delegate.resolveChunk(index, maxEntities).get
     }

--- a/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/memory/async/AsyncRepositoryOnMemorySupportByPredicate.scala
+++ b/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/memory/async/AsyncRepositoryOnMemorySupportByPredicate.scala
@@ -27,7 +27,7 @@ trait AsyncRepositoryOnMemorySupportByPredicate
   : Future[EntitiesChunk[ID, E]] = {
     val asyncCtx = getAsyncWrappedEntityIOContext(ctx)
     implicit val executor = asyncCtx.executor
-    future {
+    Future {
       implicit val syncCtx = asyncCtx.syncEntityIOContext
       delegate.filterByPredicate(predicate, index, maxEntities).get
     }

--- a/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/memory/async/AsyncRepositoryOnMemorySupportBySeq.scala
+++ b/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/memory/async/AsyncRepositoryOnMemorySupportBySeq.scala
@@ -21,7 +21,7 @@ trait AsyncRepositoryOnMemorySupportBySeq
   def resolveAll(implicit ctx: EntityIOContext[Future]): Future[Seq[E]] = {
     val asyncCtx = getAsyncWrappedEntityIOContext(ctx)
     implicit val executor = asyncCtx.executor
-    future {
+    Future {
       implicit val syncCtx = asyncCtx.syncEntityIOContext
       delegate.toSeq
     }

--- a/scala-dddbase-core/src/test/scala/org/sisioh/dddbase/core/lifecycle/memory/sync/GenericSyncRepositoryOnMemorySpec.scala
+++ b/scala-dddbase-core/src/test/scala/org/sisioh/dddbase/core/lifecycle/memory/sync/GenericSyncRepositoryOnMemorySpec.scala
@@ -45,11 +45,11 @@ class GenericSyncRepositoryOnMemorySpec extends Specification with Mockito {
         spy(new EntityImpl(id))
       }
       val repos = repository.store(entities)
-      for (i <- 0 to 9) yield {
-        there was atLeastOne(entities(i)).identity
-        repository.resolve(entities(i).identity).isFailure must_== true
-        repos.flatMap(_.result.contains(entities(i))).getOrElse(false) must_== true
-      }
+      entities must contain { (e: Entity[Identity[Int]]) =>
+        there was atLeastOne(e).identity
+        repository.resolve(e.identity).isFailure must beTrue
+        repos.map(_.entities.contains(e)).getOrElse(false) must_== true
+      }.forall
     }
     "resolve a entity by using identity" in {
       val repository = new GenericSyncRepositoryOnMemory[Identity[Int], EntityImpl]()
@@ -66,9 +66,9 @@ class GenericSyncRepositoryOnMemorySpec extends Specification with Mockito {
         spy(new EntityImpl(id))
       }
       val repos = repository.store(entities)
-      for (i <- 0 to 9) {
-        there was atLeastOne(entities(i)).identity
-      }
+      entities must contain((e: Entity[Identity[Int]]) =>
+        there was atLeastOne(e).identity
+      ).forall
       repository.resolves(entities.map(_.identity)).isSuccess must_== true
       val _entities = repos.flatMap(_.result.resolves(entities.map(_.identity))).get
       _entities must_== entities
@@ -80,9 +80,9 @@ class GenericSyncRepositoryOnMemorySpec extends Specification with Mockito {
         spy(new EntityImpl(id))
       }
       val repos = repository.store(entities)
-      for (i <- 0 to 4) {
-        there was atLeastOne(entities(i)).identity
-      }
+      entities must contain((e: Entity[Identity[Int]]) =>
+        there was atLeastOne(e).identity
+      ).forall
       repository.resolves((0 to 9 by 2).map(Identity(_)).toSeq).isSuccess must_== true
       repos.get.result.resolves((0 to 9).map(Identity(_)).toSeq).isSuccess must_== true
       val _entities = repos.flatMap(_.result.resolves(entities.map(_.identity))).get
@@ -121,10 +121,10 @@ class GenericSyncRepositoryOnMemorySpec extends Specification with Mockito {
         spy(new EntityImpl(id))
       }
       val resultWithEntity = repository.store(entities)
-      for (i <- 0 to 9) {
-        there was atLeastOne(entities(i)).identity
-        repository.resolve(entities(i).identity).isFailure must_== true
-      }
+      entities must contain { (e: Entity[Identity[Int]]) =>
+        there was atLeastOne(e).identity
+        repository.resolve(e.identity).isFailure must_== true
+      }.forall
       val resultWithEntity2 = resultWithEntity.flatMap {
         _.result.deleteByIdentities(entities.map(_.identity))
       }.get


### PR DESCRIPTION
- Scala 2.11サポートが欲しかったので、2.11と2.10のクロスビルドの設定を追加しました。
- `scala.concurrent.future`が2.11からdeprecatedになったので`scala.concurrent.Future`に変更しました。
- sbt, specs2, scalatest, sbt-idea, sbt-pgpのバージョンを最新にしました。
