### PR TITLE
[For 0.2.x branch] Update Scala version to 2.11.1 and libraries to newest.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: scala
 scala:
- - 2.10.2
+ - 2.10.4
+ - 2.11.1
 
 script:
  - "sbt ++$TRAVIS_SCALA_VERSION test"

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -2,15 +2,16 @@ import sbt._
 import Keys._
 
 object DDDBaseBuild extends Build {
-  val specs2 = "org.specs2" %% "specs2" % "2.0" % "test"
-  val scalaTest = "org.scalatest" %% "scalatest" % "1.9.1" % "test"
+  val specs2 = "org.specs2" %% "specs2" % "2.3.12" % "test"
+  val scalaTest = "org.scalatest" %% "scalatest" % "2.2.0" % "test"
   val junit = "junit" % "junit" % "4.8.1" % "test"
   val mockito = "org.mockito" % "mockito-core" % "1.9.5" % "test"
 
   lazy val commonSettings = Defaults.defaultSettings ++ Seq(
     organization := "org.sisioh",
     version := "0.2.0-SNAPSHOT",
-    scalaVersion := "2.10.3",
+    scalaVersion := "2.10.4",
+    crossScalaVersions := Seq("2.10.4", "2.11.1"),
     libraryDependencies ++= Seq(junit, scalaTest, mockito, scalaTest, specs2),
     scalacOptions ++= Seq("-feature", "-unchecked", "-deprecation"),
     shellPrompt := {

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.12.2
+sbt.version=0.13.5

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
-addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.4.0")
+addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.6.0")
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-pgp" % "0.8")
+addSbtPlugin("com.typesafe.sbt" % "sbt-pgp" % "0.8.3")
 
 logLevel := Level.Warn

--- a/release.sh
+++ b/release.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-sbt clean publish
+sbt +clean +publish
 rm -fr /tmp/repos
 mv ./repos /tmp
 git checkout gh-pages

--- a/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/forwarding/async/wrapped/AsyncWrappedSyncEntityReader.scala
+++ b/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/forwarding/async/wrapped/AsyncWrappedSyncEntityReader.scala
@@ -24,7 +24,7 @@ trait AsyncWrappedSyncEntityReader[ID <: Identifier[_], E <: Entity[ID]]
   def resolveBy(identifier: ID)(implicit ctx: Ctx) = {
     val asyncCtx = getAsyncWrappedEntityIOContext(ctx)
     implicit val executor = asyncCtx.executor
-    future {
+    Future {
       implicit val syncCtx = asyncCtx.syncEntityIOContext
       delegate.resolveBy(identifier).get
     }
@@ -33,7 +33,7 @@ trait AsyncWrappedSyncEntityReader[ID <: Identifier[_], E <: Entity[ID]]
   def existBy(identifier: ID)(implicit ctx: Ctx): Future[Boolean] = {
     val asyncCtx = getAsyncWrappedEntityIOContext(ctx)
     implicit val executor = asyncCtx.executor
-    future {
+    Future {
       implicit val syncCtx = asyncCtx.syncEntityIOContext
        delegate.existBy(identifier).get
     }

--- a/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/forwarding/async/wrapped/AsyncWrappedSyncEntityWriter.scala
+++ b/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/forwarding/async/wrapped/AsyncWrappedSyncEntityWriter.scala
@@ -29,7 +29,7 @@ trait AsyncWrappedSyncEntityWriter[ID <: Identifier[_], E <: Entity[ID]]
   def store(entity: E)(implicit ctx: Ctx): Future[AsyncResultWithEntity[This, ID, E]] = {
     val asyncCtx = getAsyncWrappedEntityIOContext(ctx)
     implicit val executor = asyncCtx.executor
-    future {
+    Future {
       implicit val syncCtx = asyncCtx.syncEntityIOContext
       val resultWithEntity = delegate.store(entity).get
       val _entity: Option[E] = Some(resultWithEntity.entity.asInstanceOf[E])
@@ -41,7 +41,7 @@ trait AsyncWrappedSyncEntityWriter[ID <: Identifier[_], E <: Entity[ID]]
   def deleteBy(identifier: ID)(implicit ctx: Ctx): Future[AsyncResultWithEntity[This, ID, E]] = {
     val asyncCtx = getAsyncWrappedEntityIOContext(ctx)
     implicit val executor = asyncCtx.executor
-    future {
+    Future {
       implicit val syncCtx = asyncCtx.syncEntityIOContext
       val resultWithEntity = delegate.deleteBy(identifier).get
       val _entity: Option[E] = Some(resultWithEntity.entity.asInstanceOf[E])

--- a/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/memory/async/AsyncRepositoryOnMemorySupportAsChunk.scala
+++ b/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/memory/async/AsyncRepositoryOnMemorySupportAsChunk.scala
@@ -20,7 +20,7 @@ trait AsyncRepositoryOnMemorySupportAsChunk
   def resolveAsChunk(index: Int, maxEntities: Int)
                     (implicit ctx: EntityIOContext[Future]): Future[EntitiesChunk[ID, E]] = {
     implicit val executor = getExecutionContext(ctx)
-    future {
+    Future {
       val subEntities = getEntities.values.toList.slice(index * maxEntities, index * maxEntities + maxEntities)
       EntitiesChunk(index, subEntities)
     }

--- a/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/memory/async/AsyncRepositoryOnMemorySupportAsPredicate.scala
+++ b/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/memory/async/AsyncRepositoryOnMemorySupportAsPredicate.scala
@@ -25,7 +25,7 @@ trait AsyncRepositoryOnMemorySupportAsPredicate
   (implicit ctx: EntityIOContext[Future])
   : Future[EntitiesChunk[ID, E]] = {
     implicit val executor = getExecutionContext(ctx)
-    future {
+    Future {
       val filteredSubEntities = getEntities.values.toList.filter(predicate)
       val index = indexOpt.getOrElse(0)
       val maxEntities = maxEntitiesOpt.getOrElse(filteredSubEntities.size)

--- a/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/memory/async/AsyncRepositoryOnMemorySupportAsSeq.scala
+++ b/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/lifecycle/memory/async/AsyncRepositoryOnMemorySupportAsSeq.scala
@@ -20,7 +20,7 @@ trait AsyncRepositoryOnMemorySupportAsSeq
 
   def resolveAll(implicit ctx: EntityIOContext[Future]): Future[Seq[E]] = {
     implicit val executor = getExecutionContext(ctx)
-    future {
+    Future {
       getEntities.values.toSeq
     }
   }

--- a/scala-dddbase-core/src/test/scala/org/sisioh/dddbase/core/lifecycle/memory/sync/GenericSyncRepositoryOnMemorySpec.scala
+++ b/scala-dddbase-core/src/test/scala/org/sisioh/dddbase/core/lifecycle/memory/sync/GenericSyncRepositoryOnMemorySpec.scala
@@ -46,11 +46,11 @@ class GenericSyncRepositoryOnMemorySpec extends Specification with Mockito {
         spy(new EntityImpl(id))
       }
       val repos = repository.multiStore(entities: _*)
-      for (i <- 0 to 9) yield {
-        there was atLeastOne(entities(i)).identifier
-        repository.resolveBy(entities(i).identifier).isFailure must_== true
-        repos.flatMap(_.result.exist(entities(i))).getOrElse(false) must_== true
-      }
+      entities must contain { (e: Entity[Identifier[Int]]) =>
+        there was atLeastOne(e).identifier
+        repository.resolveBy(e.identifier).isFailure must_== true
+        repos.map(_.entities.contains(e)).getOrElse(false) must_== true
+      }.forall
     }
     "resolve a entity by using identifier" in {
       val repository = new GenericSyncRepositoryOnMemory[Identifier[Int], EntityImpl]()
@@ -67,9 +67,9 @@ class GenericSyncRepositoryOnMemorySpec extends Specification with Mockito {
         spy(new EntityImpl(id))
       }
       val repos = repository.multiStore(entities: _*)
-      for (i <- 0 to 9) {
-        there was atLeastOne(entities(i)).identifier
-      }
+      entities must contain((e: Entity[Identifier[Int]]) =>
+        there was atLeastOne(e).identifier
+      ).forall
       repository.multiResolveBy(entities.map(_.identifier): _*).isSuccess must_== true
       val _entities = repos.flatMap(_.result.multiResolveBy(entities.map(_.identifier): _*)).get
       _entities must_== entities
@@ -81,9 +81,9 @@ class GenericSyncRepositoryOnMemorySpec extends Specification with Mockito {
         spy(new EntityImpl(id))
       }
       val repos = repository.multiStore(entities: _*)
-      for (i <- 0 to 4) {
-        there was atLeastOne(entities(i)).identifier
-      }
+      entities must contain((e: Entity[Identifier[Int]]) =>
+        there was atLeastOne(e).identifier
+      ).forall
       repository.multiResolveBy((0 to 9 by 2).map(Identifier(_)).toSeq: _*).isSuccess must_== true
       repos.get.result.multiResolveBy((0 to 9).map(Identifier(_)).toSeq: _*).isSuccess must_== true
       val _entities = repos.flatMap(_.result.multiResolveBy(entities.map(_.identifier): _*)).get
@@ -125,10 +125,10 @@ class GenericSyncRepositoryOnMemorySpec extends Specification with Mockito {
         spy(new EntityImpl(id))
       }
       val resultWithEntity = repository.multiStore(entities: _*)
-      for (i <- 0 to 9) {
-        there was atLeastOne(entities(i)).identifier
-        repository.resolveBy(entities(i).identifier).isFailure must_== true
-      }
+      entities must contain { (e: Entity[Identifier[Int]]) =>
+        there was atLeastOne(e).identifier
+        repository.resolveBy(e.identifier).isFailure must_== true
+      }.forall
       val resultWithEntity2 = resultWithEntity.flatMap {
         _.result.multiDeleteBy(entities.map(_.identifier): _*)
       }.get

--- a/scala-dddbase-event/src/test/scala/org/sisioh/dddbase/event/lifecycle/AsyncRepositoryEventSupportSpec.scala
+++ b/scala-dddbase-event/src/test/scala/org/sisioh/dddbase/event/lifecycle/AsyncRepositoryEventSupportSpec.scala
@@ -43,7 +43,7 @@ class AsyncRepositoryEventSupportSpec extends Specification {
       val repos = new TestRepository()
       val entity = new EntityImpl(Identifier(UUID.randomUUID()))
       repos.subscribe(new AsyncDomainEventSubscriber[EntityIOEvent[Identifier[UUID], EntityImpl], Unit] {
-        def handleEvent(event: EntityIOEvent[Identifier[UUID], EntityImpl])(implicit ctx: EntityIOContext[Future]): Future[Unit] = future {
+        def handleEvent(event: EntityIOEvent[Identifier[UUID], EntityImpl])(implicit ctx: EntityIOContext[Future]): Future[Unit] = Future {
           result = true
           resultEntity = event.entity
           resultEventType = event.eventType

--- a/scala-dddbase-event/src/test/scala/org/sisioh/dddbase/event/mutable/async/GenericAsyncDomainEventStoreSpec.scala
+++ b/scala-dddbase-event/src/test/scala/org/sisioh/dddbase/event/mutable/async/GenericAsyncDomainEventStoreSpec.scala
@@ -5,10 +5,9 @@ import org.sisioh.dddbase.core.model.{EntityCloneable, Identifier}
 import java.util.UUID
 import org.sisioh.dddbase.event.DomainEvent
 import org.sisioh.dddbase.core.lifecycle.memory.mutable.async.GenericAsyncRepositoryOnMemory
-import scala.concurrent.Await
+import scala.concurrent.{Await, Future}
 import scala.concurrent.duration.Duration
 import scala.concurrent.ExecutionContext.Implicits.global
-import org.sisioh.dddbase.core.lifecycle.async.AsyncEntityIOContext
 import org.sisioh.dddbase.core.lifecycle.forwarding.async.wrapped.AsyncWrappedSyncEntityIOContext
 
 class GenericAsyncDomainEventStoreSpec extends Specification {
@@ -35,11 +34,8 @@ class GenericAsyncDomainEventStoreSpec extends Specification {
       val event = new E(Identifier(UUID.randomUUID()))
       val futures = publisher.subscribe(target).publish(event)
 
-      futures.map {
-        future =>
-          val result = Await.result(future, Duration.Inf)
-          result must_== ()
-      }
+      Await.result(Future.sequence(futures), Duration.Inf)
+      success
     }
   }
 }


### PR DESCRIPTION
v0.2.xブランチにもScala 2.11.1サポートと依存ライブラリのアップデートを行いました。
https://github.com/sisioh/scala-dddbase/pull/23 に加えて、
`.travis.yml`にScalaのバージョンを2.10.4と2.11.1を書いた、という変更があります。

メインのscalaVersionは2.10.xのままにしました。2.11.xに上げるかどうかの判断はお任せします。
