### PR TITLE
Fix scm url for publishing information.

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -39,8 +39,8 @@ object DDDBaseBuild extends Build {
           </license>
         </licenses>
         <scm>
-          <url>git@github.com:sisioh/sisioh-dddbase.git</url>
-          <connection>scm:git:git@github.com:sisioh/sisioh-dddbase.git</connection>
+          <url>git@github.com:sisioh/scala-dddbase.git</url>
+          <connection>scm:git:git@github.com:sisioh/scala-dddbase.git</connection>
         </scm>
         <developers>
           <developer>


### PR DESCRIPTION
[mvnrepository.com](http://mvnrepository.com/artifact/org.sisioh/scala-dddbase-core_2.10/0.1.27)からのリンクで飛べなくて気づきました。
