### PR TITLE
Added support for Emptyidentifier.

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -9,9 +9,9 @@ object DDDBaseBuild extends Build {
 
   lazy val commonSettings = Defaults.defaultSettings ++ Seq(
     organization := "org.sisioh",
-    version := "0.2.0-SNAPSHOT",
+    version := "0.2.1-SNAPSHOT",
     scalaVersion := "2.10.4",
-    crossScalaVersions := Seq("2.10.4", "2.11.1"),
+    crossScalaVersions := Seq("2.10.4", "2.11.4"),
     scalacOptions ++= Seq("-feature", "-unchecked", "-deprecation"),
     shellPrompt := {
       "sbt (%s)> " format projectId(_)

--- a/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/model/Identifier.scala
+++ b/scala-dddbase-core/src/main/scala/org/sisioh/dddbase/core/model/Identifier.scala
@@ -61,16 +61,15 @@ abstract class AbstractOrderedIdentifier[A <% Ordered[A], ID <: Identifier[A]]
 /**
  * 識別子の値が空だった場合の例外。
  */
-case class EmptyIdentityException() extends Exception
+case class EmptyIdentifierException() extends Exception
 
 /**
  * 空の識別子を表す値オブジェクト。
  */
-private[core]
 class EmptyIdentifier
   extends Identifier[Nothing] {
 
-  def value = throw EmptyIdentityException()
+  def value = throw EmptyIdentifierException()
 
   override def equals(obj: Any): Boolean = obj match {
     case that: EmptyIdentifier => this eq that
@@ -79,7 +78,7 @@ class EmptyIdentifier
 
   override def hashCode(): Int = 31 * 1
 
-  override def toString = "EmptyIdentity"
+  override def toString = "EmptyIdentifier"
 }
 
 object EmptyIdentifier extends EmptyIdentifier
@@ -97,7 +96,7 @@ class IdentifierImpl[A](val value: A)
 
   override def hashCode = 31 * value.##
 
-  override def toString = s"Identity($value)"
+  override def toString = s"Identifier($value)"
 
 }
 

--- a/scala-dddbase-core/src/test/scala/org/sisioh/dddbase/core/model/IdentitySpec.scala
+++ b/scala-dddbase-core/src/test/scala/org/sisioh/dddbase/core/model/IdentitySpec.scala
@@ -17,14 +17,27 @@ case class NotSerializableIdentifier(value: DummyValue) extends Identifier[Dummy
 
 case class SerializableIdentifier(value: Long) extends Identifier[Long]
 
-// with IdentitySerializable[Long]
+trait UserId extends Identifier[Long]
+
+case object EmptyUserId extends EmptyIdentifier with UserId
+
+case class UserIdImpl(value: Long) extends UserId
+
+// with IdentitySerializable[Long]]
 
 class IdentitySpec extends Specification {
   "Identity" should {
+    def getUserId(n: Int): Identifier[Long] = {
+      if (n % 2 ==0)
+        new UserIdImpl(1)
+      else
+        EmptyUserId
+    }
+    val id: Identifier[Long]  = getUserId(1)
 
     "throw EmptyIdentityException when get value" in {
       val identifier: Identifier[Long] = Identifier.empty
-      identifier.value must throwA[EmptyIdentityException]
+      identifier.value must throwA[EmptyIdentifierException]
     }
 
     "throw NotSerializableExcepption when serialization not serializable identifier" in {


### PR DESCRIPTION
独自型の空IDを実装するために、EmptyIndetifierを公開しました。

``` scala
trait UserId extends Identifier[Long]

private case class UserIdImpl(value: Long) extends UserId

case object EmptyUserId extends EmptyIdentifer with UserId

object UserId {
  def apply(value: Long): UserId = 
  def empty: UserId = EmptyUserId
}
```
