### PR TITLE
Update Scala2.13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,12 @@
 language: scala
 
 scala:
-  - "2.11.6"
-  - "2.10.5"
+  - "2.13.1"
+  - "2.12.8"
+  - "2.11.7"
 
 jdk:
-  - oraclejdk8
+  - openjdk8
 
 sudo: false
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,47 +1,51 @@
-import com.typesafe.sbt.SbtScalariform
+import sbtcrossproject.CrossPlugin.autoImport.crossProject
 
-import scalariform.formatter.preferences._
+val specs2 = "org.specs2" %% "specs2-core" % "4.8.1" % Test
 
-val specs2 = "org.specs2" %% "specs2" % "2.3.12" % "test"
+val scalaTest = "org.scalatest" %% "scalatest" % "3.1.0" % Test
 
-val scalaTest = "org.scalatest" %% "scalatest" % "2.2.0" % "test"
+val scalaTestPlus = "org.scalatestplus" %% "scalatestplus-scalacheck" % "3.1.0.0-RC2" % Test
 
-val junit = "junit" % "junit" % "4.8.1" % "test"
+val scalaTestJunit = "org.scalatestplus" %% "scalatestplus-junit" % "1.0.0-M2"
 
-val mockito = "org.mockito" % "mockito-core" % "1.9.5" % "test"
+val scalaTestMockito = "org.scalatestplus" %% "scalatestplus-mockito" % "1.0.0-M2"
+
+val junit = "junit" % "junit" % "4.12" % Test
+
+val mockito = "org.mockito" % "mockito-core" % "3.1.0" % "test"
 
 def projectId(state: State) = extracted(state).currentProject.id
 
 def extracted(state: State) = Project extract state
 
-lazy val root = project.in(file("."))
+lazy val root = project
+  .in(file("."))
   .settings(name := "scala-dddbase")
   .settings(commonSettings: _*)
-  .aggregate(coreJS, coreJVM, forwardingJS, forwardingJVM, memoryJVM, memoryJS, specJVM, specJS)
+  .aggregate(
+    coreJS,
+    coreJVM,
+    forwardingJS,
+    forwardingJVM,
+    memoryJVM,
+    memoryJS,
+    specJVM,
+    specJS
+  )
 
-lazy val scalariformSettings = SbtScalariform.scalariformSettings ++ Seq(
-  ScalariformKeys.preferences :=
-    ScalariformKeys.preferences.value
-      .setPreference(AlignParameters, true)
-      .setPreference(AlignSingleLineCaseStatements, true)
-      .setPreference(DoubleIndentClassDeclaration, true)
-      .setPreference(PreserveDanglingCloseParenthesis, true)
-      .setPreference(MultilineScaladocCommentsStartOnFirstLine, false)
-)
-
-lazy val commonSettings = scalariformSettings ++ Seq(
+lazy val commonSettings = Seq(
   sonatypeProfileName := "org.sisioh",
   organization := "org.sisioh",
-  scalaVersion := "2.11.7",
-  crossScalaVersions := Seq("2.10.5", "2.11.7"),
+  scalaVersion := "2.13.1",
+  crossScalaVersions := Seq("2.11.7", "2.12.8", "2.13.1"),
   scalacOptions ++= Seq("-feature", "-unchecked", "-deprecation"),
   shellPrompt := {
     "sbt (%s)> " format projectId(_)
   },
   publishMavenStyle := true,
   publishArtifact in Test := false,
-  pomIncludeRepository := {
-    _ => false
+  pomIncludeRepository := { _ =>
+    false
   },
   pomExtra := (
     <url>https://github.com/sisioh/scala-dddbase</url>
@@ -63,7 +67,7 @@ lazy val commonSettings = scalariformSettings ++ Seq(
           <url>http://j5ik2o.me</url>
         </developer>
       </developers>
-    ),
+  ),
   credentials := {
     val ivyCredentials = (baseDirectory in LocalRootProject).value / ".credentials"
     Credentials(ivyCredentials) :: Nil
@@ -75,18 +79,21 @@ lazy val jvmCommonSettings = Seq(
     "org.scala-js" %% "scalajs-stubs" % scalaJSVersion % "provided",
     mockito,
     specs2,
-    scalaTest
+    scalaTest,
+    junit,
+    scalaTestPlus,
+    scalaTestJunit,
+    scalaTestMockito
   )
 )
 
 lazy val jsCommonSettings = Seq(
-  scalaJSOutputMode := org.scalajs.core.tools.javascript.OutputMode.ECMAScript6StrongMode
+  scalaJSOutputMode := org.scalajs.core.tools.linker.backend.OutputMode.ECMAScript6
 )
 
-lazy val core = crossProject.in(file("scala-dddbase-core")).
-  settings(
-    name := "scala-dddbase-core"
-  )
+lazy val core = crossProject(JSPlatform, JVMPlatform)
+  .in(file("scala-dddbase-core"))
+  .settings(name := "scala-dddbase-core")
   .settings(commonSettings: _*)
   .jvmSettings(jvmCommonSettings: _*)
   .jsSettings(jsCommonSettings: _*)
@@ -95,10 +102,9 @@ lazy val coreJVM = core.jvm
 
 lazy val coreJS = core.js
 
-lazy val forwarding = crossProject.in(file("scala-dddbase-lifecycle-repositories-forwarding"))
-  .settings(
-    name := "scala-dddbase-lifecycle-repositories-forwarding"
-  )
+lazy val forwarding = crossProject(JSPlatform, JVMPlatform)
+  .in(file("scala-dddbase-lifecycle-repositories-forwarding"))
+  .settings(name := "scala-dddbase-lifecycle-repositories-forwarding")
   .settings(commonSettings: _*)
   .jvmSettings(jvmCommonSettings: _*)
   .jsSettings(jsCommonSettings: _*)
@@ -108,10 +114,9 @@ lazy val forwardingJVM = forwarding.jvm
 
 lazy val forwardingJS = forwarding.js
 
-lazy val memory = crossProject.in(file("scala-dddbase-lifecycle-repositories-memory"))
-  .settings(
-    name := "scala-dddbase-lifecycle-repositories-memory"
-  )
+lazy val memory = crossProject(JSPlatform, JVMPlatform)
+  .in(file("scala-dddbase-lifecycle-repositories-memory"))
+  .settings(name := "scala-dddbase-lifecycle-repositories-memory")
   .settings(commonSettings: _*)
   .jvmSettings(jvmCommonSettings: _*)
   .jsSettings(jsCommonSettings: _*)
@@ -121,10 +126,9 @@ lazy val memoryJVM = memory.jvm
 
 lazy val memoryJS = memory.js
 
-lazy val spec = crossProject.in(file("scala-dddbase-spec"))
-  .settings(
-    name := "scala-dddbase-spec"
-  )
+lazy val spec = crossProject(JSPlatform, JVMPlatform)
+  .in(file("scala-dddbase-spec"))
+  .settings(name := "scala-dddbase-spec")
   .settings(commonSettings: _*)
   .jvmSettings(jvmCommonSettings: _*)
   .jsSettings(jsCommonSettings: _*)

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.8
+sbt.version=1.3.4

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,11 +1,11 @@
 //logLevel := Level.Warn
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-scalariform" % "1.3.0")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.3")
 
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "0.5.0")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.0")
 
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
+addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.12")
 
-addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.0")
+addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "0.6.1")
 
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.5")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.31")

--- a/scala-dddbase-core/shared/src/main/scala/org/sisioh/dddbase/core/lifecycle/EntityNotFoundException.scala
+++ b/scala-dddbase-core/shared/src/main/scala/org/sisioh/dddbase/core/lifecycle/EntityNotFoundException.scala
@@ -18,14 +18,14 @@ package org.sisioh.dddbase.core.lifecycle
 
 import org.sisioh.dddbase.core.BaseException
 
-import scala.scalajs.js.annotation.JSExport
+import scala.scalajs.js.annotation.JSExportTopLevel
 
 /**
- * リポジトリにアクセスできなかった場合の例外。
- *
- * @author j5ik2o
- */
-@JSExport
-case class EntityNotFoundException(override val message: Option[String] = None, override val cause: Option[Throwable] = None)
-  extends BaseException(message, cause)
-
+  * リポジトリにアクセスできなかった場合の例外。
+  *
+  * @author j5ik2o
+  */
+@JSExportTopLevel("EntityNotFoundException")
+case class EntityNotFoundException(override val message: Option[String] = None,
+                                   override val cause: Option[Throwable] = None)
+    extends BaseException(message, cause)

--- a/scala-dddbase-core/shared/src/main/scala/org/sisioh/dddbase/core/lifecycle/RepositoryException.scala
+++ b/scala-dddbase-core/shared/src/main/scala/org/sisioh/dddbase/core/lifecycle/RepositoryException.scala
@@ -18,13 +18,14 @@ package org.sisioh.dddbase.core.lifecycle
 
 import org.sisioh.dddbase.core.BaseException
 
-import scala.scalajs.js.annotation.JSExport
+import scala.scalajs.js.annotation.JSExportTopLevel
 
 /**
- * リポジトリにアクセスできなかった場合の例外。
- *
- * @author j5ik2o
- */
-@JSExport
-case class RepositoryException(override val message: Option[String] = None, override val cause: Option[Throwable] = None)
-  extends BaseException(message, cause)
+  * リポジトリにアクセスできなかった場合の例外。
+  *
+  * @author j5ik2o
+  */
+@JSExportTopLevel("RepositoryException")
+case class RepositoryException(override val message: Option[String] = None,
+                               override val cause: Option[Throwable] = None)
+    extends BaseException(message, cause)

--- a/scala-dddbase-core/shared/src/main/scala/org/sisioh/dddbase/core/lifecycle/async/AsyncEntityIOContext.scala
+++ b/scala-dddbase-core/shared/src/main/scala/org/sisioh/dddbase/core/lifecycle/async/AsyncEntityIOContext.scala
@@ -16,44 +16,47 @@
 package org.sisioh.dddbase.core.lifecycle.async
 
 import org.sisioh.dddbase.core.lifecycle.EntityIOContext
-import scala.concurrent.{ Future, ExecutionContext }
+import scala.concurrent.{Future, ExecutionContext}
 
 /**
- * `org.sisioh.dddbase.core.lifecycle.EntityIOContext`の非同期版。
- */
+  * `org.sisioh.dddbase.core.lifecycle.EntityIOContext`の非同期版。
+  */
 trait AsyncEntityIOContext extends EntityIOContext[Future] {
 
   /**
-   * `scala.concurrent.ExecutionContext`
-   */
+    * `scala.concurrent.ExecutionContext`
+    */
   val executor: ExecutionContext
 
 }
 
 /**
- * コンパニオンオブジェクト。
- */
+  * コンパニオンオブジェクト。
+  */
 object AsyncEntityIOContext {
 
   /**
-   * ファクトリメソッド。
-   *
-   * @param executor `scala.concurrent.ExecutionContext`
-   * @return `org.sisioh.dddbase.core.lifecycle.async.AsyncEntityIOContext`
-   */
+    * ファクトリメソッド。
+    *
+    * @param executor `scala.concurrent.ExecutionContext`
+    * @return `org.sisioh.dddbase.core.lifecycle.async.AsyncEntityIOContext`
+    */
   def apply()(implicit executor: ExecutionContext): AsyncEntityIOContext =
     new AsyncEntityIOContextImpl()
 
   /**
-   * エクストラクタメソッド。
-   *
-   * @param asyncEntityIOContext `org.sisioh.dddbase.core.lifecycle.async.AsyncEntityIOContext`
-   * @return 構成要素
-   */
-  def unapply(asyncEntityIOContext: AsyncEntityIOContext): Option[(ExecutionContext)] =
+    * エクストラクタメソッド。
+    *
+    * @param asyncEntityIOContext `org.sisioh.dddbase.core.lifecycle.async.AsyncEntityIOContext`
+    * @return 構成要素
+    */
+  def unapply(
+    asyncEntityIOContext: AsyncEntityIOContext
+  ): Option[(ExecutionContext)] =
     Some(asyncEntityIOContext.executor)
 
 }
 
-private[async] case class AsyncEntityIOContextImpl(implicit val executor: ExecutionContext)
-  extends AsyncEntityIOContext
+private[async] case class AsyncEntityIOContextImpl()(
+  implicit val executor: ExecutionContext
+) extends AsyncEntityIOContext

--- a/scala-dddbase-core/shared/src/main/scala/org/sisioh/dddbase/core/model/Identifier.scala
+++ b/scala-dddbase-core/shared/src/main/scala/org/sisioh/dddbase/core/model/Identifier.scala
@@ -16,43 +16,45 @@
  */
 package org.sisioh.dddbase.core.model
 
-import scala.scalajs.js.annotation.JSExport
+import scala.scalajs.js.annotation.JSExportTopLevel
 
 /**
- * エンティティの識別子を表すトレイト。
- *
- * エンティティで用いられる識別子を型として表現することを目的としている。
- *
- * @tparam A 識別子の値を表す型
- */
+  * エンティティの識別子を表すトレイト。
+  *
+  * エンティティで用いられる識別子を型として表現することを目的としている。
+  *
+  * @tparam A 識別子の値を表す型
+  */
 trait Identifier[+A] extends Serializable {
 
   /**
-   * 識別子の値を取得する。
-   *
-   * @return 識別子の値
-   */
+    * 識別子の値を取得する。
+    *
+    * @return 識別子の値
+    */
   def value: A
 
 }
 
 /**
- * 順序をサポートした`Identifier`。
- *
- * @tparam A 識別子の値を表す型
- * @tparam ID 識別子の型
- */
+  * 順序をサポートした`Identifier`。
+  *
+  * @tparam A 識別子の値を表す型
+  * @tparam ID 識別子の型
+  */
 trait OrderedIdentifier[A, ID <: Identifier[A]]
-  extends Identifier[A] with Ordered[ID]
+    extends Identifier[A]
+    with Ordered[ID]
 
 /**
- * `OrderedIdentifier`の骨格実装。
- *
- * @tparam A 識別子の値を表す型
- * @tparam ID 識別子の型
- */
-abstract class AbstractOrderedIdentifier[A <% Ordered[A], ID <: Identifier[A]]
-    extends OrderedIdentifier[A, ID] {
+  * `OrderedIdentifier`の骨格実装。
+  *
+  * @tparam A 識別子の値を表す型
+  * @tparam ID 識別子の型
+  */
+abstract class AbstractOrderedIdentifier[A, ID <: Identifier[A]](
+  implicit ev: A => Ordered[A]
+) extends OrderedIdentifier[A, ID] {
 
   def compare(that: ID): Int = {
     value compare that.value
@@ -61,17 +63,16 @@ abstract class AbstractOrderedIdentifier[A <% Ordered[A], ID <: Identifier[A]]
 }
 
 /**
- * 識別子の値が空だった場合の例外。
- */
-@JSExport
+  * 識別子の値が空だった場合の例外。
+  */
+@JSExportTopLevel("EmptyIdentifierException")
 case class EmptyIdentifierException() extends Exception
 
 /**
- * 空の識別子を表す値オブジェクト。
- */
-@JSExport
-class EmptyIdentifier
-    extends Identifier[Nothing] {
+  * 空の識別子を表す値オブジェクト。
+  */
+@JSExportTopLevel("EmptyIdentifier")
+class EmptyIdentifier extends Identifier[Nothing] {
 
   def value = throw EmptyIdentifierException()
 
@@ -85,11 +86,9 @@ class EmptyIdentifier
   override def toString = "EmptyIdentifier"
 }
 
-@JSExport
 object EmptyIdentifier extends EmptyIdentifier
 
-private[core] class IdentifierImpl[A](val value: A)
-    extends Identifier[A] {
+private[core] class IdentifierImpl[A](val value: A) extends Identifier[A] {
 
   override def equals(obj: Any) = obj match {
     case that: EmptyIdentifier => false
@@ -105,35 +104,34 @@ private[core] class IdentifierImpl[A](val value: A)
 }
 
 /**
- * コンパニオンオブジェクト。
- */
-@JSExport
+  * コンパニオンオブジェクト。
+  */
+@JSExportTopLevel("Identifier")
 object Identifier {
 
   /**
-   * `Identifier`を生成する。
-   *
-   * @param value 識別子の値
-   * @tparam A 識別子の値の型
-   * @return `Identifier`
-   */
+    * `Identifier`を生成する。
+    *
+    * @param value 識別子の値
+    * @tparam A 識別子の値の型
+    * @return `Identifier`
+    */
   def apply[A](value: A): Identifier[A] = new IdentifierImpl(value)
 
   /**
-   * 空の`Identifier`を返す。
-   *
-   * @return `Identifier`
-   */
+    * 空の`Identifier`を返す。
+    *
+    * @return `Identifier`
+    */
   def empty[A]: Identifier[A] = EmptyIdentifier
 
   /**
-   * 抽出子メソッド。
-   *
-   * @param v `Identifier`
-   * @tparam A 識別子の値の型
-   * @return 識別子の値
-   */
+    * 抽出子メソッド。
+    *
+    * @param v `Identifier`
+    * @tparam A 識別子の値の型
+    * @return 識別子の値
+    */
   def unapply[A](v: Identifier[A]): Option[A] = Some(v.value)
 
 }
-

--- a/scala-dddbase-lifecycle-repositories-forwarding/jvm/src/test/scala/org/sisioh/dddbase/lifecycle/forwarding/async/ForwardingAsyncRepositorySpec.scala
+++ b/scala-dddbase-lifecycle-repositories-forwarding/jvm/src/test/scala/org/sisioh/dddbase/lifecycle/forwarding/async/ForwardingAsyncRepositorySpec.scala
@@ -3,16 +3,17 @@ package org.sisioh.dddbase.lifecycle.forwarding.async
 import java.util.UUID
 import org.sisioh.dddbase.core.lifecycle.EntityNotFoundException
 import org.sisioh.dddbase.core.lifecycle.async.AsyncRepository
-import org.sisioh.dddbase.core.model.{ EntityCloneable, Entity, Identifier }
+import org.sisioh.dddbase.core.model.{EntityCloneable, Entity, Identifier}
 import org.sisioh.dddbase.lifecycle.forwarding.TestAsyncRepository
 import org.sisioh.dddbase.lifecycle.forwarding.async.wrapped.AsyncWrappedSyncEntityIOContext
-import org.specs2.mock.Mockito
+import org.mockito.Mockito._
+import org.mockito.Mockito.{atLeastOnce => leastOnce}
 import org.specs2.mutable.Specification
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration.Duration
-import scala.concurrent.{ ExecutionContext, Future, Await }
+import scala.concurrent.{ExecutionContext, Future, Await}
 
-class ForwardingAsyncRepositorySpec extends Specification with Mockito {
+class ForwardingAsyncRepositorySpec extends Specification {
 
   class EntityImpl(val identifier: Identifier[UUID])
       extends Entity[Identifier[UUID]]
@@ -27,19 +28,24 @@ class ForwardingAsyncRepositorySpec extends Specification with Mockito {
 
   val id = Identifier(UUID.randomUUID)
 
-  class TestRepForwardingRepositoryImpl(protected val delegate: AsyncRepository[Identifier[UUID], EntityImpl])(implicit val executor: ExecutionContext)
+  class TestRepForwardingRepositoryImpl(
+    protected val delegate: AsyncRepository[Identifier[UUID], EntityImpl]
+  )(implicit val executor: ExecutionContext)
       extends ForwardingAsyncRepository[Identifier[UUID], EntityImpl] {
-
     type This = TestRepForwardingRepositoryImpl
 
     type Delegate = AsyncRepository[Identifier[UUID], EntityImpl]
 
-    protected def createInstance(state: Future[(Delegate#This, Option[EntityImpl])]): Future[(This, Option[EntityImpl])] = {
-      state.map {
-        r =>
-          val state = new TestRepForwardingRepositoryImpl(r._1.asInstanceOf[Delegate#This])
-          (state, r._2)
-      }
+    protected def createInstance(
+      state: Future[(Delegate#This, Option[EntityImpl])]
+    ): Future[(This, Option[EntityImpl])] = {
+      state.map { r =>
+        val state =
+          new TestRepForwardingRepositoryImpl(r._1.asInstanceOf[Delegate#This])(
+            executor
+          )
+        (state, r._2)
+      }(executor)
     }
 
   }
@@ -53,12 +59,11 @@ class ForwardingAsyncRepositorySpec extends Specification with Mockito {
       repository(entity.identifier) = entity
       val future = repository.store(entity)
       val resultWithEntity = Await.result(future, Duration.Inf)
-      there was atLeastOne(entity).identifier
+      verify(entity, leastOnce()).identifier
       (resultWithEntity.result ne repository) must beTrue
-      val future2 = future.flatMap {
-        r =>
-          val tr = new TestRepForwardingRepositoryImpl(r.result)
-          tr.resolveBy(id)
+      val future2 = future.flatMap { r =>
+        val tr = new TestRepForwardingRepositoryImpl(r.result)
+        tr.resolveBy(id)
       }
       Await.result(future2, Duration.Inf) must_== entity
     }
@@ -67,12 +72,11 @@ class ForwardingAsyncRepositorySpec extends Specification with Mockito {
       val entity = spy(new EntityImpl(id))
       val future = repository.store(entity)
       val resultWithEntity = Await.result(future, Duration.Inf)
-      there was atLeastOne(entity).identifier
+      verify(entity, leastOnce()).identifier
       (resultWithEntity.result ne repository) must beTrue
-      val future2 = future.flatMap {
-        r =>
-          val tr = new TestRepForwardingRepositoryImpl(r.result)
-          tr.resolveBy(id)
+      val future2 = future.flatMap { r =>
+        val tr = new TestRepForwardingRepositoryImpl(r.result)
+        tr.resolveBy(id)
       }
       Await.result(future2, Duration.Inf) must_== entity
     }
@@ -81,24 +85,27 @@ class ForwardingAsyncRepositorySpec extends Specification with Mockito {
       val entity = spy(new EntityImpl(id))
       val future = repository.store(entity)
       val resultWithEntity = Await.result(future, Duration.Inf)
-      there was atLeastOne(entity).identifier
+      verify(entity, leastOnce()).identifier
       (resultWithEntity.result ne repository) must beTrue
-      val future2 = future.flatMap {
-        r =>
-          val tr = new TestRepForwardingRepositoryImpl(r.result)
-          tr.deleteBy(id)
+      val future2 = future.flatMap { r =>
+        val tr = new TestRepForwardingRepositoryImpl(r.result)
+        tr.deleteBy(id)
       }
       Await.result(future2, Duration.Inf) must not beNull
     }
     "not resolve a entity by using a non-existent identifier" in {
-      val repository = new TestRepForwardingRepositoryImpl(new TestAsyncRepository[Identifier[UUID], EntityImpl]())
+      val repository = new TestRepForwardingRepositoryImpl(
+        new TestAsyncRepository[Identifier[UUID], EntityImpl]()
+      )
       val future = repository.resolveBy(id)
       Await.ready(future, Duration.Inf)
       future.value.get.isFailure must_== true
       future.value.get.get must throwA[EntityNotFoundException]
     }
     "not delete a entity by using a non-existent identifier" in {
-      val repository = new TestRepForwardingRepositoryImpl(new TestAsyncRepository[Identifier[UUID], EntityImpl]())
+      val repository = new TestRepForwardingRepositoryImpl(
+        new TestAsyncRepository[Identifier[UUID], EntityImpl]()
+      )
       val future = repository.deleteBy(id)
       Await.ready(future, Duration.Inf)
       future.value.get.isFailure must_== true

--- a/scala-dddbase-lifecycle-repositories-forwarding/jvm/src/test/scala/org/sisioh/dddbase/lifecycle/forwarding/async/wrapped/AsyncWrappedSyncRepositorySpec.scala
+++ b/scala-dddbase-lifecycle-repositories-forwarding/jvm/src/test/scala/org/sisioh/dddbase/lifecycle/forwarding/async/wrapped/AsyncWrappedSyncRepositorySpec.scala
@@ -2,17 +2,16 @@ package org.sisioh.dddbase.lifecycle.forwarding.async.wrapped
 
 import java.util.UUID
 import org.sisioh.dddbase.core.model._
-import org.specs2.mock.Mockito
+import org.mockito.Mockito._
+import org.mockito.Mockito.{atLeastOnce => leastOnce}
 import org.specs2.mutable.Specification
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration.Duration
-import scala.concurrent.{ Await, ExecutionContext }
+import scala.concurrent.{Await, ExecutionContext}
 import org.sisioh.dddbase.core.lifecycle.EntityNotFoundException
-import org.sisioh.dddbase.core.lifecycle.sync.{ SyncResultWithEntity, SyncRepository }
-import scala.util.Try
 import org.sisioh.dddbase.lifecycle.forwarding.TestSyncMutableRepository
 
-class AsyncWrappedSyncRepositorySpec extends Specification with Mockito {
+class AsyncWrappedSyncRepositorySpec extends Specification {
 
   class EntityImpl(val identifier: Identifier[UUID])
       extends Entity[Identifier[UUID]]
@@ -23,14 +22,18 @@ class AsyncWrappedSyncRepositorySpec extends Specification with Mockito {
     }
   }
 
-  class ForwardingAsyncWrappedRepositoryImpl(protected val delegate: TestSyncMutableRepository[Identifier[UUID], EntityImpl])(implicit val executor: ExecutionContext)
+  class ForwardingAsyncWrappedRepositoryImpl(
+    protected val delegate: TestSyncMutableRepository[Identifier[UUID], EntityImpl]
+  )(implicit val executor: ExecutionContext)
       extends AsyncWrappedSyncRepository[Identifier[UUID], EntityImpl] {
 
     type This = ForwardingAsyncWrappedRepositoryImpl
 
     type Delegate = TestSyncMutableRepository[Identifier[UUID], EntityImpl]
 
-    protected def createInstance(state: (Delegate#This, Option[EntityImpl])): (This, Option[EntityImpl]) = {
+    protected def createInstance(
+      state: (Delegate#This, Option[EntityImpl])
+    ): (This, Option[EntityImpl]) = {
       (this.asInstanceOf[This], state._2)
     }
 
@@ -42,54 +45,64 @@ class AsyncWrappedSyncRepositorySpec extends Specification with Mockito {
 
   "The repository" should {
     "have stored entity with empty identifier" in {
-      val repository = new ForwardingAsyncWrappedRepositoryImpl(TestSyncMutableRepository())
+      val repository =
+        new ForwardingAsyncWrappedRepositoryImpl(TestSyncMutableRepository())
       val entity = spy(new EntityImpl(EmptyIdentifier))
       val repos = repository.store(entity)
       Await.ready(repos, Duration.Inf)
-      there was atLeastOne(entity).identifier
+      verify(entity, leastOnce()).identifier
       Await.result(repository.resolveBy(EmptyIdentifier), Duration.Inf) must_== entity
       Await.result(repos.flatMap(_.result.exist(entity)), Duration.Inf) must_== true
     }
     "have stored entity" in {
-      val repository = new ForwardingAsyncWrappedRepositoryImpl(TestSyncMutableRepository())
+      val repository =
+        new ForwardingAsyncWrappedRepositoryImpl(TestSyncMutableRepository())
       val entity = spy(new EntityImpl(id))
       val repos = repository.store(entity)
       Await.ready(repos, Duration.Inf)
-      there was atLeastOne(entity).identifier
+      verify(entity, leastOnce()).identifier
       Await.result(repository.resolveBy(id), Duration.Inf) must_== entity
       Await.result(repos.flatMap(_.result.exist(entity)), Duration.Inf) must_== true
     }
     "resolve a entity by using identifier" in {
-      val repository = new ForwardingAsyncWrappedRepositoryImpl(TestSyncMutableRepository())
+      val repository =
+        new ForwardingAsyncWrappedRepositoryImpl(TestSyncMutableRepository())
       val entity = spy(new EntityImpl(id))
       val repos = repository.store(entity)
       Await.ready(repos, Duration.Inf)
-      there was atLeastOne(entity).identifier
+      verify(entity, leastOnce()).identifier
       Await.result(repository.resolveBy(id), Duration.Inf) must_== entity
       Await.result(repos.flatMap(_.result.resolveBy(id)), Duration.Inf) must_== entity
     }
     "delete a entity by using identifier" in {
-      val repository = new ForwardingAsyncWrappedRepositoryImpl(TestSyncMutableRepository())
+      val repository =
+        new ForwardingAsyncWrappedRepositoryImpl(TestSyncMutableRepository())
       val entity = spy(new EntityImpl(id))
       val repos = repository.store(entity)
       Await.ready(repos, Duration.Inf)
-      there was atLeastOne(entity).identifier
+      verify(entity, leastOnce()).identifier
       Await.result(repository.resolveBy(id), Duration.Inf) must_== entity
       Await.result(repos.flatMap(_.result.deleteBy(id)), Duration.Inf) must_!= repos
     }
     "fail to resolve a entity by a non-existent identifier" in {
-      val repository = new ForwardingAsyncWrappedRepositoryImpl(TestSyncMutableRepository())
+      val repository =
+        new ForwardingAsyncWrappedRepositoryImpl(TestSyncMutableRepository())
       Await.result(repository.resolveBy(id).recover {
         case ex: EntityNotFoundException => true
       }, Duration.Inf) must_== true
-      Await.result(repository.resolveBy(id), Duration.Inf) must throwA[EntityNotFoundException]
+      Await.result(repository.resolveBy(id), Duration.Inf) must throwA[
+        EntityNotFoundException
+      ]
     }
     "fail to delete a entity by a non-existent identifier" in {
-      val repository = new ForwardingAsyncWrappedRepositoryImpl(TestSyncMutableRepository())
+      val repository =
+        new ForwardingAsyncWrappedRepositoryImpl(TestSyncMutableRepository())
       Await.result(repository.deleteBy(id).recover {
         case ex: EntityNotFoundException => true
       }, Duration.Inf) must_== true
-      Await.result(repository.deleteBy(id), Duration.Inf) must throwA[EntityNotFoundException]
+      Await.result(repository.deleteBy(id), Duration.Inf) must throwA[
+        EntityNotFoundException
+      ]
     }
   }
 }

--- a/scala-dddbase-lifecycle-repositories-forwarding/jvm/src/test/scala/org/sisioh/dddbase/lifecycle/forwarding/sync/ForwardingSyncRepositorySpec.scala
+++ b/scala-dddbase-lifecycle-repositories-forwarding/jvm/src/test/scala/org/sisioh/dddbase/lifecycle/forwarding/sync/ForwardingSyncRepositorySpec.scala
@@ -2,21 +2,27 @@ package org.sisioh.dddbase.lifecycle.forwarding.sync
 
 import java.util.UUID
 import org.sisioh.dddbase.core.lifecycle._
-import org.sisioh.dddbase.core.lifecycle.sync.{ SyncEntityIOContext, SyncRepository }
-import org.sisioh.dddbase.core.model.{ EntityCloneable, Entity, Identifier }
-import org.specs2.mock.Mockito
+import org.sisioh.dddbase.core.lifecycle.sync.{
+  SyncEntityIOContext,
+  SyncRepository
+}
+import org.sisioh.dddbase.core.model.{EntityCloneable, Entity, Identifier}
+import org.mockito.Mockito._
+import org.mockito.Mockito.{atLeastOnce => leastOnce}
 import org.specs2.mutable.Specification
 import scala.util.Try
 import org.sisioh.dddbase.lifecycle.forwarding.TestSyncRepository
 
-class ForwardingSyncRepositorySpec extends Specification with Mockito {
+class ForwardingSyncRepositorySpec extends Specification {
 
   class EntityImpl(val identifier: Identifier[UUID])
       extends Entity[Identifier[UUID]]
       with EntityCloneable[Identifier[UUID], EntityImpl]
       with Ordered[EntityImpl] {
 
-    def compare(that: ForwardingSyncRepositorySpec.this.type#EntityImpl): Int = {
+    def compare(
+      that: ForwardingSyncRepositorySpec.this.type#EntityImpl
+    ): Int = {
       identifier.value.compareTo(that.identifier.value)
     }
 
@@ -24,18 +30,22 @@ class ForwardingSyncRepositorySpec extends Specification with Mockito {
 
   val id = Identifier(UUID.randomUUID())
 
-  class TestRepForwardingSyncRepositoryImpl(protected val delegate: TestSyncRepository[Identifier[UUID], EntityImpl])
-      extends ForwardingSyncRepository[Identifier[UUID], EntityImpl] {
+  class TestRepForwardingSyncRepositoryImpl(
+    protected val delegate: TestSyncRepository[Identifier[UUID], EntityImpl]
+  ) extends ForwardingSyncRepository[Identifier[UUID], EntityImpl] {
 
     type This = TestRepForwardingSyncRepositoryImpl
 
     type Delegate = TestSyncRepository[Identifier[UUID], EntityImpl]
 
-    protected def createInstance(state: Try[(Delegate#This, Option[EntityImpl])]): Try[(TestRepForwardingSyncRepositoryImpl#This, Option[EntityImpl])] = {
-      state.map {
-        r =>
-          val state = new TestRepForwardingSyncRepositoryImpl(r._1.asInstanceOf[TestSyncRepository[Identifier[UUID], EntityImpl]])
-          (state, r._2)
+    protected def createInstance(
+      state: Try[(Delegate#This, Option[EntityImpl])]
+    ): Try[(TestRepForwardingSyncRepositoryImpl#This, Option[EntityImpl])] = {
+      state.map { r =>
+        val state = new TestRepForwardingSyncRepositoryImpl(
+          r._1.asInstanceOf[TestSyncRepository[Identifier[UUID], EntityImpl]]
+        )
+        (state, r._2)
       }
     }
 
@@ -48,50 +58,53 @@ class ForwardingSyncRepositorySpec extends Specification with Mockito {
       val repository = new TestSyncRepository[Identifier[UUID], EntityImpl]()
       val entity = spy(new EntityImpl(id))
       val resultWithEntity = repository.store(entity)
-      there was atLeastOne(entity).identifier
+      verify(entity, leastOnce()).identifier
       repository.resolveBy(id).isFailure must_== true
       (resultWithEntity.get.result ne repository) must beTrue
-      resultWithEntity.flatMap {
-        r =>
+      resultWithEntity
+        .flatMap { r =>
           val tr = new TestRepForwardingSyncRepositoryImpl(r.result)
           tr.exist(entity)
-      }.getOrElse(false) must_== true
+        }
+        .getOrElse(false) must_== true
     }
     "resolve a entity by using identifier" in {
       val repository = new TestSyncRepository[Identifier[UUID], EntityImpl]()
       val entity = spy(new EntityImpl(id))
       val resultWithEntity = repository.store(entity)
-      there was atLeastOne(entity).identifier
+      verify(entity, leastOnce()).identifier
       (resultWithEntity.get.result ne repository) must beTrue
       repository.resolveBy(id).isFailure must_== true
-      resultWithEntity.flatMap {
-        r =>
-          val tr = new TestRepForwardingSyncRepositoryImpl(r.result)
-          tr.resolveBy(id)
+      resultWithEntity.flatMap { r =>
+        val tr = new TestRepForwardingSyncRepositoryImpl(r.result)
+        tr.resolveBy(id)
       }.get must_== entity
     }
     "delete a entity by using identifier" in {
       val repository = new TestSyncRepository[Identifier[UUID], EntityImpl]()
       val entity = spy(new EntityImpl(id))
       val resultWithEntity = repository.store(entity)
-      there was atLeastOne(entity).identifier
+      verify(entity, leastOnce()).identifier
       (resultWithEntity.get.result ne repository) must beTrue
       repository.resolveBy(id).isFailure must_== true
-      val resultWithEntity2 = resultWithEntity.flatMap {
-        r =>
-          val tr = new TestRepForwardingSyncRepositoryImpl(r.result)
-          tr.deleteBy(id)
+      val resultWithEntity2 = resultWithEntity.flatMap { r =>
+        val tr = new TestRepForwardingSyncRepositoryImpl(r.result)
+        tr.deleteBy(id)
       }.get
       resultWithEntity2.result must_!= repository
       resultWithEntity2.entity must_== entity
     }
     "fail to resolve a entity by a non-existent identifier" in {
-      val repository = new TestRepForwardingSyncRepositoryImpl(new TestSyncRepository[Identifier[UUID], EntityImpl]())
+      val repository = new TestRepForwardingSyncRepositoryImpl(
+        new TestSyncRepository[Identifier[UUID], EntityImpl]()
+      )
       repository.resolveBy(id).isFailure must_== true
       repository.resolveBy(id).get must throwA[EntityNotFoundException]
     }
     "fail to delete a entity by a non-existent identifier" in {
-      val repository = new TestRepForwardingSyncRepositoryImpl(new TestSyncRepository[Identifier[UUID], EntityImpl]())
+      val repository = new TestRepForwardingSyncRepositoryImpl(
+        new TestSyncRepository[Identifier[UUID], EntityImpl]()
+      )
       repository.deleteBy(id).isFailure must_== true
       repository.deleteBy(id).get must throwA[EntityNotFoundException]
     }

--- a/scala-dddbase-lifecycle-repositories-forwarding/jvm/src/test/scala/org/sisioh/dddbase/lifecycle/forwarding/sync/wrapped/SyncWrappedAsyncRepositorySpec.scala
+++ b/scala-dddbase-lifecycle-repositories-forwarding/jvm/src/test/scala/org/sisioh/dddbase/lifecycle/forwarding/sync/wrapped/SyncWrappedAsyncRepositorySpec.scala
@@ -4,14 +4,18 @@ import java.util.UUID
 import org.sisioh.dddbase.core.lifecycle.EntityNotFoundException
 import org.sisioh.dddbase.core.model._
 import org.sisioh.dddbase.lifecycle.forwarding.async.wrapped.AsyncWrappedSyncEntityIOContext
-import org.sisioh.dddbase.lifecycle.forwarding.{ TestAsyncMutableRepository, TestAsyncRepository }
-import org.specs2.mock.Mockito
+import org.sisioh.dddbase.lifecycle.forwarding.{
+  TestAsyncMutableRepository,
+  TestAsyncRepository
+}
+import org.mockito.Mockito._
+import org.mockito.Mockito.{atLeastOnce => leastOnce}
 import org.specs2.mutable.Specification
 import scala.concurrent.ExecutionContext
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration.Duration
 
-class SyncWrappedAsyncRepositorySpec extends Specification with Mockito {
+class SyncWrappedAsyncRepositorySpec extends Specification {
 
   class EntityImpl(val identifier: Identifier[UUID])
       extends Entity[Identifier[UUID]]
@@ -22,14 +26,18 @@ class SyncWrappedAsyncRepositorySpec extends Specification with Mockito {
     }
   }
 
-  class ForwardingSyncWrappedRepositoryImpl(protected val delegate: TestAsyncMutableRepository[Identifier[UUID], EntityImpl])(implicit val executor: ExecutionContext)
+  class ForwardingSyncWrappedRepositoryImpl(
+    protected val delegate: TestAsyncMutableRepository[Identifier[UUID], EntityImpl]
+  )(implicit val executor: ExecutionContext)
       extends SyncWrappedAsyncRepository[Identifier[UUID], EntityImpl] {
 
     type This = ForwardingSyncWrappedRepositoryImpl
 
     type Delegate = TestAsyncMutableRepository[Identifier[UUID], EntityImpl]
 
-    protected def createInstance(state: (Delegate#This, Option[EntityImpl])): (This, Option[EntityImpl]) = {
+    protected def createInstance(
+      state: (Delegate#This, Option[EntityImpl])
+    ): (This, Option[EntityImpl]) = {
       (this.asInstanceOf[This], state._2)
     }
 
@@ -38,53 +46,73 @@ class SyncWrappedAsyncRepositorySpec extends Specification with Mockito {
 
   val id = Identifier(UUID.randomUUID)
 
-  implicit val ctx = SyncWrappedAsyncEntityIOContext(AsyncWrappedSyncEntityIOContext())
+  implicit val ctx = SyncWrappedAsyncEntityIOContext(
+    AsyncWrappedSyncEntityIOContext()
+  )
 
   "The repository" should {
     "have stored entity with empty identifier" in {
-      val repository = new ForwardingSyncWrappedRepositoryImpl(TestAsyncMutableRepository[Identifier[UUID], EntityImpl]())
+      val repository = new ForwardingSyncWrappedRepositoryImpl(
+        TestAsyncMutableRepository[Identifier[UUID], EntityImpl]()
+      )
       val entity = spy(new EntityImpl(EmptyIdentifier))
       val repos = repository.store(entity)
-      there was atLeastOne(entity).identifier
+      verify(entity, leastOnce()).identifier
       repository.resolveBy(EmptyIdentifier).get must_== entity
       repos.flatMap(_.result.exist(entity)).get must_== true
     }
     "have stored entity" in {
-      val repository = new ForwardingSyncWrappedRepositoryImpl(TestAsyncMutableRepository[Identifier[UUID], EntityImpl]())
+      val repository = new ForwardingSyncWrappedRepositoryImpl(
+        TestAsyncMutableRepository[Identifier[UUID], EntityImpl]()
+      )
       val entity = spy(new EntityImpl(id))
       val repos = repository.store(entity)
-      there was atLeastOne(entity).identifier
+      verify(entity, leastOnce()).identifier
       repository.resolveBy(id).get must_== entity
       repos.flatMap(_.result.exist(entity)).get must_== true
     }
     "resolve a entity by using identifier" in {
-      val repository = new ForwardingSyncWrappedRepositoryImpl(TestAsyncMutableRepository[Identifier[UUID], EntityImpl]())
+      val repository = new ForwardingSyncWrappedRepositoryImpl(
+        TestAsyncMutableRepository[Identifier[UUID], EntityImpl]()
+      )
       val entity = spy(new EntityImpl(id))
       val resultWithEntity = repository.store(entity)
-      there was atLeastOne(entity).identifier
+      verify(entity, leastOnce()).identifier
       repository.resolveBy(id).get must_== entity
       resultWithEntity.flatMap(_.result.resolveBy(id)).get must_== entity
     }
     "delete a entity by using identifier" in {
-      val repository = new ForwardingSyncWrappedRepositoryImpl(TestAsyncMutableRepository[Identifier[UUID], EntityImpl]())
+      val repository = new ForwardingSyncWrappedRepositoryImpl(
+        TestAsyncMutableRepository[Identifier[UUID], EntityImpl]()
+      )
       val entity = spy(new EntityImpl(id))
       val resultWithEntity = repository.store(entity)
-      there was atLeastOne(entity).identifier
+      verify(entity, leastOnce()).identifier
       repository.resolveBy(id).get must_== entity
       resultWithEntity.flatMap(_.result.deleteBy(id)) must_!= resultWithEntity.get.result
     }
     "fail to resolve a entity by a non-existent identifier" in {
-      val repository = new ForwardingSyncWrappedRepositoryImpl(TestAsyncMutableRepository[Identifier[UUID], EntityImpl]())
-      repository.resolveBy(id).recover {
-        case ex: EntityNotFoundException => true
-      }.get must_== true
+      val repository = new ForwardingSyncWrappedRepositoryImpl(
+        TestAsyncMutableRepository[Identifier[UUID], EntityImpl]()
+      )
+      repository
+        .resolveBy(id)
+        .recover {
+          case ex: EntityNotFoundException => true
+        }
+        .get must_== true
       repository.resolveBy(id).get must throwA[EntityNotFoundException]
     }
     "fail to delete a entity by a non-existent identifier" in {
-      val repository = new ForwardingSyncWrappedRepositoryImpl(TestAsyncMutableRepository[Identifier[UUID], EntityImpl]())
-      repository.deleteBy(id).recover {
-        case ex: EntityNotFoundException => true
-      }.get must_== true
+      val repository = new ForwardingSyncWrappedRepositoryImpl(
+        TestAsyncMutableRepository[Identifier[UUID], EntityImpl]()
+      )
+      repository
+        .deleteBy(id)
+        .recover {
+          case ex: EntityNotFoundException => true
+        }
+        .get must_== true
       repository.deleteBy(id).get must throwA[EntityNotFoundException]
     }
   }

--- a/scala-dddbase-lifecycle-repositories-memory/jvm/src/test/scala/org/sisioh/dddbase/lifecycle/memory/async/GenericAsyncRepositoryOnMemorySpec.scala
+++ b/scala-dddbase-lifecycle-repositories-memory/jvm/src/test/scala/org/sisioh/dddbase/lifecycle/memory/async/GenericAsyncRepositoryOnMemorySpec.scala
@@ -1,15 +1,22 @@
 package org.sisioh.dddbase.lifecycle.memory.async
 
+import org.mockito.Mockito._
+//FIXME verificationModeのatLeastOnceが競合するため、名称を変更
+import org.mockito.Mockito.{atLeastOnce => leastOnce}
+
 import concurrent.duration.Duration
 import org.sisioh.dddbase.core.lifecycle.EntityNotFoundException
-import org.sisioh.dddbase.core.lifecycle.async.{ AsyncResultWithEntities, AsyncResultWithEntity }
+import org.sisioh.dddbase.core.lifecycle.async.{
+  AsyncResultWithEntities,
+  AsyncResultWithEntity
+}
 import org.sisioh.dddbase.core.model._
-import org.specs2.mock.Mockito
-import org.specs2.mutable._
+import org.specs2.mutable.Specification
+
 import scala.concurrent.Await
 import scala.concurrent.ExecutionContext.Implicits.global
 
-class GenericAsyncRepositoryOnMemorySpec extends Specification with Mockito {
+class GenericAsyncRepositoryOnMemorySpec extends Specification {
 
   sequential
 
@@ -18,7 +25,9 @@ class GenericAsyncRepositoryOnMemorySpec extends Specification with Mockito {
       with EntityCloneable[Identifier[Int], EntityImpl]
       with Ordered[EntityImpl] {
 
-    def compare(that: GenericAsyncRepositoryOnMemorySpec.this.type#EntityImpl): Int = {
+    def compare(
+      that: GenericAsyncRepositoryOnMemorySpec.this.type#EntityImpl
+    ): Int = {
       identifier.value.compareTo(that.identifier.value)
     }
 
@@ -31,37 +40,38 @@ class GenericAsyncRepositoryOnMemorySpec extends Specification with Mockito {
   "The repository" should {
 
     "have stored enitty with empty identifier" in {
-      val repository = new GenericAsyncRepositoryOnMemory[Identifier[Int], EntityImpl]()
+      val repository =
+        new GenericAsyncRepositoryOnMemory[Identifier[Int], EntityImpl]()
       val entity = spy(new EntityImpl(EmptyIdentifier))
       repository(entity.identifier) = entity
-      val future = repository.store(entity).flatMap {
-        asyncRepos =>
-          asyncRepos.result.existBy(EmptyIdentifier)
+      val future = repository.store(entity).flatMap { asyncRepos =>
+        asyncRepos.result.existBy(EmptyIdentifier)
       }
       Await.ready(future, Duration.Inf)
-      there was atLeastOne(entity).identifier
+      verify(entity, leastOnce()).identifier
       Await.result(repository.resolveBy(EmptyIdentifier).recover {
         case ex: EntityNotFoundException => true
       }, Duration.Inf) must_== true
       future.value.get.get must_== true
     }
     "have stored entity" in {
-      val repository = new GenericAsyncRepositoryOnMemory[Identifier[Int], EntityImpl]()
+      val repository =
+        new GenericAsyncRepositoryOnMemory[Identifier[Int], EntityImpl]()
       val entity = spy(new EntityImpl(id))
       repository(entity.identifier) = entity
-      val future = repository.store(entity).flatMap {
-        asyncRepos =>
-          asyncRepos.result.existBy(id)
+      val future = repository.store(entity).flatMap { asyncRepos =>
+        asyncRepos.result.existBy(id)
       }
       Await.ready(future, Duration.Inf)
-      there was atLeastOne(entity).identifier
+      verify(entity, leastOnce()).identifier
       Await.result(repository.resolveBy(id).recover {
         case ex: EntityNotFoundException => true
       }, Duration.Inf) must_== true
       future.value.get.get must_== true
     }
     "have stored entities" in {
-      val repository = new GenericAsyncRepositoryOnMemory[Identifier[Int], EntityImpl]()
+      val repository =
+        new GenericAsyncRepositoryOnMemory[Identifier[Int], EntityImpl]()
       val entities = for (i <- 0 to 9) yield {
         val id = Identifier(i)
         spy(new EntityImpl(id))
@@ -73,80 +83,78 @@ class GenericAsyncRepositoryOnMemorySpec extends Specification with Mockito {
       }
       Await.ready(future, Duration.Inf)
       for (i <- 0 to 9) {
-        there was atLeastOne(entities(i)).identifier
-        Await.result(
-          repository.resolveBy(entities(i).identifier).recover {
-            case ex: EntityNotFoundException => true
-          }, Duration.Inf
-        ) must_== true
+        verify(entities(i), leastOnce()).identifier
+        Await.result(repository.resolveBy(entities(i).identifier).recover {
+          case ex: EntityNotFoundException => true
+        }, Duration.Inf) must_== true
       }
       future.value.get.get must_== true
     }
     "resolve entity by using a identifier" in {
-      val repository = new GenericAsyncRepositoryOnMemory[Identifier[Int], EntityImpl]()
+      val repository =
+        new GenericAsyncRepositoryOnMemory[Identifier[Int], EntityImpl]()
       val entity = spy(new EntityImpl(id))
-      val future = repository.store(entity).flatMap {
-        asyncRepos =>
-          asyncRepos.result.resolveBy(id)
+      val future = repository.store(entity).flatMap { asyncRepos =>
+        asyncRepos.result.resolveBy(id)
       }
       Await.ready(future, Duration.Inf)
-      there was atLeastOne(entity).identifier
+      verify(entity, leastOnce()).identifier
       Await.result(repository.resolveBy(id).recover {
         case ex: EntityNotFoundException => true
       }, Duration.Inf) must_== true
       future.value.get.get must_== entity
     }
     "resolve entities by using a identifier" in {
-      val repository = new GenericAsyncRepositoryOnMemory[Identifier[Int], EntityImpl]()
+      val repository =
+        new GenericAsyncRepositoryOnMemory[Identifier[Int], EntityImpl]()
       val entities = for (i <- 0 to 9) yield {
         val id = Identifier(i)
         spy(new EntityImpl(id))
       }
-      val future = repository.storeMulti(entities: _*).flatMap {
-        asyncRepos =>
-          asyncRepos.result.resolveByMulti(entities.map(_.identifier): _*)
+      val future = repository.storeMulti(entities: _*).flatMap { asyncRepos =>
+        asyncRepos.result.resolveByMulti(entities.map(_.identifier): _*)
       }
       Await.ready(future, Duration.Inf)
       for (i <- 0 to 9) {
-        there was atLeastOne(entities(i)).identifier
-        Await.result(
-          repository.resolveBy(entities(i).identifier).recover {
-            case ex: EntityNotFoundException => true
-          }, Duration.Inf
-        ) must_== true
+        verify(entities(i), leastOnce()).identifier
+        Await.result(repository.resolveBy(entities(i).identifier).recover {
+          case ex: EntityNotFoundException => true
+        }, Duration.Inf) must_== true
       }
       future.value.get.get must_== entities
     }
     "resolve entities by using a identifier" in {
-      val repository = new GenericAsyncRepositoryOnMemory[Identifier[Int], EntityImpl]()
+      val repository =
+        new GenericAsyncRepositoryOnMemory[Identifier[Int], EntityImpl]()
       val entities = for (i <- 0 to 9 by 2) yield {
         val id = Identifier(i)
         spy(new EntityImpl(id))
       }
-      val future = repository.storeMulti(entities: _*).flatMap {
-        asyncRepos =>
-          asyncRepos.result.resolveByMulti(entities.map(_.identifier): _*)
+      val future = repository.storeMulti(entities: _*).flatMap { asyncRepos =>
+        asyncRepos.result.resolveByMulti(entities.map(_.identifier): _*)
       }
       Await.ready(future, Duration.Inf)
-      entities.foreach {
-        entity =>
-          there was atLeastOne(entity).identifier
-          Await.result(
-            repository.resolveBy(entity.identifier).recover {
-              case ex: EntityNotFoundException => true
-            }, Duration.Inf
-          ) must_== true
+      entities.foreach { entity =>
+        verify(entity, leastOnce()).identifier
+        Await.result(repository.resolveBy(entity.identifier).recover {
+          case ex: EntityNotFoundException => true
+        }, Duration.Inf) must_== true
       }
-      Await.result(repository.resolveByMulti(entities.map(_.identifier): _*), Duration.Inf) must_== Seq.empty
+      Await.result(
+        repository.resolveByMulti(entities.map(_.identifier): _*),
+        Duration.Inf
+      ) must_== Seq.empty
       val r = repository.storeMulti(entities: _*).flatMap {
         resultWithEntities =>
-          resultWithEntities.result.resolveByMulti((0 to 9).map(e => Identifier(e)).toSeq: _*)
+          resultWithEntities.result
+            .resolveByMulti((0 to 9).map(e => Identifier(e)).toSeq: _*)
       }
       Await.result(r, Duration.Inf).size must_!= 0
       future.value.get.get must_== entities
     }
     "delete entity by using a identifier" in {
-      val repository = new GenericAsyncRepositoryOnMemory[Identifier[Int], EntityImpl]()
+      val repository =
+        new GenericAsyncRepositoryOnMemory[Identifier[Int], EntityImpl]()
       val entity = spy(new EntityImpl(id))
       val future = repository.store(entity).flatMap {
         case AsyncResultWithEntity(repos1, _) =>
@@ -156,16 +164,15 @@ class GenericAsyncRepositoryOnMemorySpec extends Specification with Mockito {
           }
       }
       Await.ready(future, Duration.Inf)
-      there was atLeastOne(entity).identifier
-      Await.result(
-        repository.resolveBy(id).recover {
-          case ex: EntityNotFoundException => true
-        }, Duration.Inf
-      ) must_== true
+      verify(entity, leastOnce()).identifier
+      Await.result(repository.resolveBy(id).recover {
+        case ex: EntityNotFoundException => true
+      }, Duration.Inf) must_== true
       future.value.get.get must_== false
     }
     "delete entities by using a identifier" in {
-      val repository = new GenericAsyncRepositoryOnMemory[Identifier[Int], EntityImpl]()
+      val repository =
+        new GenericAsyncRepositoryOnMemory[Identifier[Int], EntityImpl]()
       val entities = for (i <- 0 to 9) yield {
         val id = Identifier(i)
         spy(new EntityImpl(id))
@@ -179,24 +186,24 @@ class GenericAsyncRepositoryOnMemorySpec extends Specification with Mockito {
       }
       Await.ready(future, Duration.Inf)
       for (i <- 0 to 9) {
-        there was atLeastOne(entities(i)).identifier
-        Await.result(
-          repository.resolveBy(entities(i).identifier).recover {
-            case ex: EntityNotFoundException => true
-          }, Duration.Inf
-        ) must_== true
+        verify(entities(i), leastOnce()).identifier
+        Await.result(repository.resolveBy(entities(i).identifier).recover {
+          case ex: EntityNotFoundException => true
+        }, Duration.Inf) must_== true
       }
       future.value.get.get must_== false
     }
     "not resolve a entity by using a non-existent identifier" in {
-      val repository = new GenericAsyncRepositoryOnMemory[Identifier[Int], EntityImpl]()
+      val repository =
+        new GenericAsyncRepositoryOnMemory[Identifier[Int], EntityImpl]()
       val future = repository.resolveBy(id)
       Await.ready(future, Duration.Inf)
       future.value.get.isFailure must_== true
       future.value.get.get must throwA[EntityNotFoundException]
     }
     "not delete a entity by using a non-existent identifier" in {
-      val repository = new GenericAsyncRepositoryOnMemory[Identifier[Int], EntityImpl]()
+      val repository =
+        new GenericAsyncRepositoryOnMemory[Identifier[Int], EntityImpl]()
       val future = repository.deleteBy(id)
       Await.ready(future, Duration.Inf)
       future.value.get.isFailure must_== true

--- a/scala-dddbase-lifecycle-repositories-memory/jvm/src/test/scala/org/sisioh/dddbase/lifecycle/memory/mutable/async/GenericAsyncRepositoryOnMemorySpec.scala
+++ b/scala-dddbase-lifecycle-repositories-memory/jvm/src/test/scala/org/sisioh/dddbase/lifecycle/memory/mutable/async/GenericAsyncRepositoryOnMemorySpec.scala
@@ -4,13 +4,14 @@ import java.util.UUID
 import org.sisioh.dddbase.core.lifecycle.EntityNotFoundException
 import org.sisioh.dddbase.core.model._
 import org.sisioh.dddbase.lifecycle.forwarding.async.wrapped.AsyncWrappedSyncEntityIOContext
-import org.specs2.mock.Mockito
+import org.mockito.Mockito._
+import org.mockito.Mockito.{atLeastOnce => leastOnce}
 import org.specs2.mutable._
 import scala.concurrent.Await
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration.Duration
 
-class GenericAsyncRepositoryOnMemorySpec extends Specification with Mockito {
+class GenericAsyncRepositoryOnMemorySpec extends Specification {
 
   sequential
 
@@ -18,7 +19,9 @@ class GenericAsyncRepositoryOnMemorySpec extends Specification with Mockito {
       extends Entity[Identifier[UUID]]
       with EntityCloneable[Identifier[UUID], EntityImpl]
       with Ordered[EntityImpl] {
-    def compare(that: GenericAsyncRepositoryOnMemorySpec.this.type#EntityImpl): Int = {
+    def compare(
+      that: GenericAsyncRepositoryOnMemorySpec.this.type#EntityImpl
+    ): Int = {
       identifier.value.compareTo(that.identifier.value)
     }
   }
@@ -29,54 +32,64 @@ class GenericAsyncRepositoryOnMemorySpec extends Specification with Mockito {
 
   "The repository" should {
     "have stored entity with empty identifier" in {
-      val repository = GenericAsyncRepositoryOnMemory[Identifier[UUID], EntityImpl]()
+      val repository =
+        GenericAsyncRepositoryOnMemory[Identifier[UUID], EntityImpl]()
       val entity = spy(new EntityImpl(EmptyIdentifier))
       val repos = repository.store(entity)
       Await.ready(repos, Duration.Inf)
-      there was atLeastOne(entity).identifier
+      verify(entity, leastOnce()).identifier
       Await.result(repository.resolveBy(EmptyIdentifier), Duration.Inf) must_== entity
       Await.result(repos.flatMap(_.result.exist(entity)), Duration.Inf) must_== true
     }
     "have stored entity" in {
-      val repository = GenericAsyncRepositoryOnMemory[Identifier[UUID], EntityImpl]()
+      val repository =
+        GenericAsyncRepositoryOnMemory[Identifier[UUID], EntityImpl]()
       val entity = spy(new EntityImpl(id))
       val repos = repository.store(entity)
       Await.ready(repos, Duration.Inf)
-      there was atLeastOne(entity).identifier
+      verify(entity, leastOnce()).identifier
       Await.result(repository.resolveBy(id), Duration.Inf) must_== entity
       Await.result(repos.flatMap(_.result.exist(entity)), Duration.Inf) must_== true
     }
     "resolve a entity by using identifier" in {
-      val repository = GenericAsyncRepositoryOnMemory[Identifier[UUID], EntityImpl]()
+      val repository =
+        GenericAsyncRepositoryOnMemory[Identifier[UUID], EntityImpl]()
       val entity = spy(new EntityImpl(id))
       val repos = repository.store(entity)
       Await.ready(repos, Duration.Inf)
-      there was atLeastOne(entity).identifier
+      verify(entity, leastOnce()).identifier
       Await.result(repository.resolveBy(id), Duration.Inf) must_== entity
       Await.result(repos.flatMap(_.result.resolveBy(id)), Duration.Inf) must_== entity
     }
     "delete a entity by using identifier" in {
-      val repository = GenericAsyncRepositoryOnMemory[Identifier[UUID], EntityImpl]()
+      val repository =
+        GenericAsyncRepositoryOnMemory[Identifier[UUID], EntityImpl]()
       val entity = spy(new EntityImpl(id))
       val repos = repository.store(entity)
       Await.ready(repos, Duration.Inf)
-      there was atLeastOne(entity).identifier
+      verify(entity, leastOnce()).identifier
       Await.result(repository.resolveBy(id), Duration.Inf) must_== entity
       Await.result(repos.flatMap(_.result.deleteBy(id)), Duration.Inf) must_!= repos
     }
     "fail to resolve a entity by a non-existent identifier" in {
-      val repository = GenericAsyncRepositoryOnMemory[Identifier[UUID], EntityImpl]()
+      val repository =
+        GenericAsyncRepositoryOnMemory[Identifier[UUID], EntityImpl]()
       Await.result(repository.resolveBy(id).recover {
         case ex: EntityNotFoundException => true
       }, Duration.Inf) must_== true
-      Await.result(repository.resolveBy(id), Duration.Inf) must throwA[EntityNotFoundException]
+      Await.result(repository.resolveBy(id), Duration.Inf) must throwA[
+        EntityNotFoundException
+      ]
     }
     "fail to delete a entity by a non-existent identifier" in {
-      val repository = GenericAsyncRepositoryOnMemory[Identifier[UUID], EntityImpl]()
+      val repository =
+        GenericAsyncRepositoryOnMemory[Identifier[UUID], EntityImpl]()
       Await.result(repository.deleteBy(id).recover {
         case ex: EntityNotFoundException => true
       }, Duration.Inf) must_== true
-      Await.result(repository.deleteBy(id), Duration.Inf) must throwA[EntityNotFoundException]
+      Await.result(repository.deleteBy(id), Duration.Inf) must throwA[
+        EntityNotFoundException
+      ]
     }
   }
 }

--- a/scala-dddbase-lifecycle-repositories-memory/jvm/src/test/scala/org/sisioh/dddbase/lifecycle/memory/mutable/sync/GenericSyncRepositoryOnMemoryAsChunkSpec.scala
+++ b/scala-dddbase-lifecycle-repositories-memory/jvm/src/test/scala/org/sisioh/dddbase/lifecycle/memory/mutable/sync/GenericSyncRepositoryOnMemoryAsChunkSpec.scala
@@ -1,12 +1,11 @@
 package org.sisioh.dddbase.lifecycle.memory.mutable.sync
 
 import org.sisioh.dddbase.core.lifecycle.sync.SyncEntityIOContext
-import org.sisioh.dddbase.core.model.{ Identifier, EntityCloneable, Entity }
+import org.sisioh.dddbase.core.model.{Identifier, EntityCloneable, Entity}
 import org.sisioh.dddbase.lifecycle.memory.sync.SyncRepositoryOnMemorySupportAsChunk
-import org.specs2.mock.Mockito
 import org.specs2.mutable._
 
-class GenericSyncRepositoryOnMemoryAsChunkSpec extends Specification with Mockito {
+class GenericSyncRepositoryOnMemoryAsChunkSpec extends Specification {
 
   sequential
 

--- a/scala-dddbase-lifecycle-repositories-memory/jvm/src/test/scala/org/sisioh/dddbase/lifecycle/memory/mutable/sync/GenericSyncRepositoryOnMemoryAsPredicateSpec.scala
+++ b/scala-dddbase-lifecycle-repositories-memory/jvm/src/test/scala/org/sisioh/dddbase/lifecycle/memory/mutable/sync/GenericSyncRepositoryOnMemoryAsPredicateSpec.scala
@@ -1,12 +1,11 @@
 package org.sisioh.dddbase.lifecycle.memory.mutable.sync
 
 import org.sisioh.dddbase.core.lifecycle.sync.SyncEntityIOContext
-import org.sisioh.dddbase.core.model.{ Identifier, EntityCloneable, Entity }
+import org.sisioh.dddbase.core.model.{Identifier, EntityCloneable, Entity}
 import org.sisioh.dddbase.lifecycle.memory.sync.SyncRepositoryOnMemorySupportAsPredicate
-import org.specs2.mock.Mockito
 import org.specs2.mutable._
 
-class GenericSyncRepositoryOnMemoryAsPredicateSpec extends Specification with Mockito {
+class GenericSyncRepositoryOnMemoryAsPredicateSpec extends Specification {
 
   sequential
 
@@ -39,9 +38,11 @@ class GenericSyncRepositoryOnMemoryAsPredicateSpec extends Specification with Mo
         repository.store(entity).get.result
       }
 
-      val chunk = repository.filterBy({
-        e => e.identifier.value % 2 == 0
-      }, Some(0), Some(5)).get
+      val chunk = repository
+        .filterBy({ e =>
+          e.identifier.value % 2 == 0
+        }, Some(0), Some(5))
+        .get
 
       chunk.index must_== 0
       chunk.entities.size must_== 5

--- a/scala-dddbase-lifecycle-repositories-memory/jvm/src/test/scala/org/sisioh/dddbase/lifecycle/memory/mutable/sync/GenericSyncRepositoryOnMemorySpec.scala
+++ b/scala-dddbase-lifecycle-repositories-memory/jvm/src/test/scala/org/sisioh/dddbase/lifecycle/memory/mutable/sync/GenericSyncRepositoryOnMemorySpec.scala
@@ -1,14 +1,16 @@
 package org.sisioh.dddbase.lifecycle.memory.mutable.sync
 
 import java.util.UUID
+
+import org.mockito.Mockito._
+import org.mockito.Mockito.{atLeastOnce => leastOnce}
 import org.sisioh.dddbase.core.lifecycle.EntityNotFoundException
 import org.sisioh.dddbase.core.model._
-import org.specs2.mock.Mockito
 import org.specs2.mutable._
-import scala.Some
+
 import org.sisioh.dddbase.lifecycle.memory.sync.SyncRepositoryOnMemorySupportAsOption
 
-class GenericSyncRepositoryOnMemorySpec extends Specification with Mockito {
+class GenericSyncRepositoryOnMemorySpec extends Specification {
 
   sequential
 
@@ -16,7 +18,9 @@ class GenericSyncRepositoryOnMemorySpec extends Specification with Mockito {
       extends Entity[Identifier[UUID]]
       with EntityCloneable[Identifier[UUID], EntityImpl]
       with Ordered[EntityImpl] {
-    def compare(that: GenericSyncRepositoryOnMemorySpec.this.type#EntityImpl): Int = {
+    def compare(
+      that: GenericSyncRepositoryOnMemorySpec.this.type#EntityImpl
+    ): Int = {
       identifier.value.compareTo(that.identifier.value)
     }
   }
@@ -27,26 +31,29 @@ class GenericSyncRepositoryOnMemorySpec extends Specification with Mockito {
 
   "The repository" should {
     "have stored entity with empty identifier" in {
-      val repository = GenericSyncRepositoryOnMemory[Identifier[UUID], EntityImpl]()
+      val repository =
+        GenericSyncRepositoryOnMemory[Identifier[UUID], EntityImpl]()
       val entity = spy(new EntityImpl(EmptyIdentifier))
       val repos = repository.store(entity)
-      there was atLeastOne(entity).identifier
+      verify(entity, leastOnce()).identifier
       repository.resolveBy(EmptyIdentifier).get must_== entity
       repos.flatMap(_.result.exist(entity)).getOrElse(false) must_== true
     }
     "have stored entity" in {
-      val repository = GenericSyncRepositoryOnMemory[Identifier[UUID], EntityImpl]()
+      val repository =
+        GenericSyncRepositoryOnMemory[Identifier[UUID], EntityImpl]()
       val entity = spy(new EntityImpl(id))
       val repos = repository.store(entity)
-      there was atLeastOne(entity).identifier
+      verify(entity, leastOnce()).identifier
       repository.resolveBy(id).get must_== entity
       repos.flatMap(_.result.exist(entity)).getOrElse(false) must_== true
     }
     "resolve a entity by using identifier" in {
-      val repository = GenericSyncRepositoryOnMemory[Identifier[UUID], EntityImpl]()
+      val repository =
+        GenericSyncRepositoryOnMemory[Identifier[UUID], EntityImpl]()
       val entity = spy(new EntityImpl(id))
       val repos = repository.store(entity)
-      there was atLeastOne(entity).identifier
+      verify(entity, leastOnce()).identifier
       repository.resolveBy(id).get must_== entity
       repos.flatMap(_.result.resolveBy(id)).get must_== entity
     }
@@ -60,27 +67,30 @@ class GenericSyncRepositoryOnMemorySpec extends Specification with Mockito {
       val repository = new TestSyncRepository
       val entity = spy(new EntityImpl(id))
       val repos = repository.store(entity)
-      there was atLeastOne(entity).identifier
-      repository.resolveAsOptionBy(id) must_== Some(entity)
-      repos.map(_.result.resolveAsOptionBy(id)).get must_== Some(entity)
+      verify(entity, leastOnce()).identifier
+      repository.resolveAsOptionBy(id) must beSome(entity)
+      repos.map(_.result.resolveAsOptionBy(id)).get must beSome(entity)
     }
     "delete a entity by using identifier" in {
-      val repository = GenericSyncRepositoryOnMemory[Identifier[UUID], EntityImpl]()
+      val repository =
+        GenericSyncRepositoryOnMemory[Identifier[UUID], EntityImpl]()
       val entity = spy(new EntityImpl(id))
       val repos = repository.store(entity)
-      there was atLeastOne(entity).identifier
+      verify(entity, leastOnce()).identifier
       repository.resolveBy(id).get must_== entity
       val resultWithEntity = repos.flatMap(_.result.deleteBy(id)).get
       resultWithEntity.result must_!= repos
       resultWithEntity.entity must_== entity
     }
     "fail to resolve a entity by a non-existent identifier" in {
-      val repository = GenericSyncRepositoryOnMemory[Identifier[UUID], EntityImpl]()
+      val repository =
+        GenericSyncRepositoryOnMemory[Identifier[UUID], EntityImpl]()
       repository.resolveBy(id).isFailure must_== true
       repository.resolveBy(id).get must throwA[EntityNotFoundException]
     }
     "fail to delete a entity by a non-existent identifier" in {
-      val repository = GenericSyncRepositoryOnMemory[Identifier[UUID], EntityImpl]()
+      val repository =
+        GenericSyncRepositoryOnMemory[Identifier[UUID], EntityImpl]()
       repository.deleteBy(id).isFailure must_== true
       repository.deleteBy(id).get must throwA[EntityNotFoundException]
     }

--- a/scala-dddbase-lifecycle-repositories-memory/jvm/src/test/scala/org/sisioh/dddbase/lifecycle/memory/sync/GenericSyncRepositoryOnMemorySpec.scala
+++ b/scala-dddbase-lifecycle-repositories-memory/jvm/src/test/scala/org/sisioh/dddbase/lifecycle/memory/sync/GenericSyncRepositoryOnMemorySpec.scala
@@ -2,16 +2,21 @@ package org.sisioh.dddbase.lifecycle.memory.sync
 
 import org.sisioh.dddbase.core.lifecycle.EntityNotFoundException
 import org.sisioh.dddbase.core.model._
-import org.specs2.mock.Mockito
-import org.specs2.mutable._
+import org.mockito.Mockito._
+import org.mockito.Mockito.{atLeastOnce => leastOnce}
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers._
+import org.scalatest.Inspectors.forAll
 
-class GenericSyncRepositoryOnMemorySpec extends Specification with Mockito {
+class GenericSyncRepositoryOnMemorySpec extends AnyFreeSpec {
 
   class EntityImpl(val identifier: Identifier[Int])
       extends Entity[Identifier[Int]]
       with EntityCloneable[Identifier[Int], EntityImpl]
       with Ordered[EntityImpl] {
-    def compare(that: GenericSyncRepositoryOnMemorySpec.this.type#EntityImpl): Int = {
+    def compare(
+      that: GenericSyncRepositoryOnMemorySpec.this.type#EntityImpl
+    ): Int = {
       identifier.value.compareTo(that.identifier.value)
     }
   }
@@ -20,137 +25,165 @@ class GenericSyncRepositoryOnMemorySpec extends Specification with Mockito {
 
   import GenericSyncRepositoryOnMemory.Implicits.defaultEntityIOContext
 
-  "The repository" should {
+  "The repository" - {
     "have stored enitty with empty identifier" in {
-      val repository = new GenericSyncRepositoryOnMemory[Identifier[Int], EntityImpl]()
+      val repository =
+        new GenericSyncRepositoryOnMemory[Identifier[Int], EntityImpl]()
       val entity = spy(new EntityImpl(EmptyIdentifier))
       val resultWithEntity = repository.store(entity)
-      there was atLeastOne(entity).identifier
-      repository.resolveBy(id).isFailure must_== true
-      resultWithEntity.flatMap(_.result.exist(entity)).getOrElse(false) must_== true
-      (resultWithEntity.get.result ne repository) must beTrue
+      verify(entity, leastOnce()).identifier
+      repository.resolveBy(id).isFailure shouldBe true
+      resultWithEntity
+        .flatMap(_.result.exist(entity))
+        .getOrElse(false) shouldBe true
+      (resultWithEntity.get.result ne repository) shouldBe true
     }
     "have stored entity" in {
-      val repository = new GenericSyncRepositoryOnMemory[Identifier[Int], EntityImpl]()
+      val repository =
+        new GenericSyncRepositoryOnMemory[Identifier[Int], EntityImpl]()
       val entity = spy(new EntityImpl(id))
       val repos = repository.store(entity)
-      there was atLeastOne(entity).identifier
-      repository.resolveBy(id).isFailure must_== true
-      repos.flatMap(_.result.exist(entity)).getOrElse(false) must_== true
+      verify(entity, leastOnce()).identifier
+      repository.resolveBy(id).isFailure shouldBe true
+      repos.flatMap(_.result.exist(entity)).getOrElse(false) shouldBe true
     }
+    //TODO: これより下で使われるforAllの変更箇所が元と同じ意味なのか要確認
     "have stored entities" in {
-      val repository = new GenericSyncRepositoryOnMemory[Identifier[Int], EntityImpl]()
+      val repository =
+        new GenericSyncRepositoryOnMemory[Identifier[Int], EntityImpl]()
       val entities = for (i <- 0 to 9) yield {
         val id = Identifier(i)
         spy(new EntityImpl(id))
       }
       val repos = repository.storeMulti(entities: _*)
-      entities must contain { (e: Entity[Identifier[Int]]) =>
-        there was atLeastOne(e).identifier
-        repository.resolveBy(e.identifier).isFailure must_== true
-        repos.map(_.entities.contains(e)).getOrElse(false) must_== true
-      }.forall
+      forAll(entities) { (e: Entity[Identifier[Int]]) =>
+        verify(e, leastOnce()).identifier
+        repository.resolveBy(e.identifier).isFailure shouldBe true
+        repos.map(_.entities.contains(e)).getOrElse(false) shouldBe true
+      }
     }
     "resolve a entity by using identifier" in {
-      val repository = new GenericSyncRepositoryOnMemory[Identifier[Int], EntityImpl]()
+      val repository =
+        new GenericSyncRepositoryOnMemory[Identifier[Int], EntityImpl]()
       val entity = spy(new EntityImpl(id))
       val repos = repository.store(entity)
-      there was atLeastOne(entity).identifier
-      repository.resolveBy(id).isFailure must_== true
-      repos.flatMap(_.result.resolveBy(id)).get must_== entity
+      verify(entity, leastOnce()).identifier
+      repository.resolveBy(id).isFailure shouldBe true
+      repos.flatMap(_.result.resolveBy(id)).get shouldBe entity
     }
+
     "resolve a entities by using identifier" in {
-      val repository = new GenericSyncRepositoryOnMemory[Identifier[Int], EntityImpl]()
+      val repository =
+        new GenericSyncRepositoryOnMemory[Identifier[Int], EntityImpl]()
       val entities = for (i <- 0 to 9) yield {
         val id = Identifier(i)
         spy(new EntityImpl(id))
       }
       val repos = repository.storeMulti(entities: _*)
-      entities must contain((e: Entity[Identifier[Int]]) =>
-        there was atLeastOne(e).identifier
-      ).forall
-      repository.resolveByMulti(entities.map(_.identifier): _*).isSuccess must_== true
-      val _entities = repos.flatMap(_.result.resolveByMulti(entities.map(_.identifier): _*)).get
-      _entities must_== entities
+      forAll(entities) { e: Entity[Identifier[Int]] =>
+        verify(e, leastOnce()).identifier
+      }
+      repository
+        .resolveByMulti(entities.map(_.identifier): _*)
+        .isSuccess shouldBe true
+      val _entities = repos
+        .flatMap(_.result.resolveByMulti(entities.map(_.identifier): _*))
+        .get
+      _entities shouldBe entities
     }
-    "resolve a entities by using identifier" in {
-      val repository = new GenericSyncRepositoryOnMemory[Identifier[Int], EntityImpl]()
+    //FIXME "error" Duplicate test name
+    "resolve a entities by using identifier2" in {
+      val repository =
+        new GenericSyncRepositoryOnMemory[Identifier[Int], EntityImpl]()
       val entities = for (i <- 0 to 9 by 2) yield {
         val id = Identifier(i)
         spy(new EntityImpl(id))
       }
       val repos = repository.storeMulti(entities: _*)
-      entities must contain((e: Entity[Identifier[Int]]) =>
-        there was atLeastOne(e).identifier
-      ).forall
-      repository.resolveByMulti((0 to 9 by 2).map(Identifier(_)).toSeq: _*).isSuccess must_== true
-      repos.get.result.resolveByMulti((0 to 9).map(Identifier(_)).toSeq: _*).isSuccess must_== true
-      val _entities = repos.flatMap(_.result.resolveByMulti(entities.map(_.identifier): _*)).get
-      _entities must_== entities
+      forAll(entities) { (e: Entity[Identifier[Int]]) =>
+        verify(e, leastOnce()).identifier
+      }
+      repository
+        .resolveByMulti((0 to 9 by 2).map(Identifier(_)).toSeq: _*)
+        .isSuccess shouldBe true
+      repos.get.result
+        .resolveByMulti((0 to 9).map(Identifier(_)).toSeq: _*)
+        .isSuccess shouldBe true
+      val _entities = repos
+        .flatMap(_.result.resolveByMulti(entities.map(_.identifier): _*))
+        .get
+      _entities shouldBe entities
     }
     "resolveOption a entity by using identifier" in {
       type ID = Identifier[Int]
-      class TestSyncRepository(entities: Map[Identifier[Int], EntityImpl] = Map.empty)
-          extends AbstractSyncRepositoryOnMemory[ID, EntityImpl](entities)
+      class TestSyncRepository(
+        entities: Map[Identifier[Int], EntityImpl] = Map.empty
+      ) extends AbstractSyncRepositoryOnMemory[ID, EntityImpl](entities)
           with SyncRepositoryOnMemorySupportAsOption[ID, EntityImpl] {
         type This = TestSyncRepository
 
-        override protected def createInstance(entities: Map[Identifier[Int], EntityImpl]): This =
+        override protected def createInstance(
+          entities: Map[Identifier[Int], EntityImpl]
+        ): This =
           new TestSyncRepository(entities)
       }
       val repository = new TestSyncRepository
       val entity = spy(new EntityImpl(id))
       val repos = repository.store(entity)
-      there was atLeastOne(entity).identifier
-      val resolveOptionTry = repos.map {
-        r =>
-          r.result.resolveAsOptionBy(id)
+      verify(entity, leastOnce()).identifier
+      val resolveOptionTry = repos.map { r =>
+        r.result.resolveAsOptionBy(id)
       }.get
-      resolveOptionTry.get must_== entity
+      resolveOptionTry.get shouldBe entity
     }
     "delete a entity by using identifier" in {
-      val repository = new GenericSyncRepositoryOnMemory[Identifier[Int], EntityImpl]()
+      val repository =
+        new GenericSyncRepositoryOnMemory[Identifier[Int], EntityImpl]()
       val entity = spy(new EntityImpl(id))
       val resultWithEntity = repository.store(entity)
-      there was atLeastOne(entity).identifier
-      repository.resolveBy(id).isFailure must_== true
-      val resultWithEntity2 = resultWithEntity.flatMap(_.result.deleteBy(id)).get
-      (resultWithEntity2.result ne repository) must beTrue
-      resultWithEntity2.entity must_== entity
+      verify(entity, leastOnce()).identifier
+      repository.resolveBy(id).isFailure shouldBe true
+      val resultWithEntity2 =
+        resultWithEntity.flatMap(_.result.deleteBy(id)).get
+      (resultWithEntity2.result ne repository) shouldBe true
+      resultWithEntity2.entity shouldBe entity
     }
     "delete a entities by using identifier" in {
-      val repository = new GenericSyncRepositoryOnMemory[Identifier[Int], EntityImpl]()
+      val repository =
+        new GenericSyncRepositoryOnMemory[Identifier[Int], EntityImpl]()
       val entities = for (i <- 0 to 9) yield {
         val id = Identifier(i)
         spy(new EntityImpl(id))
       }
       val resultWithEntity = repository.storeMulti(entities: _*)
-      entities must contain { (e: Entity[Identifier[Int]]) =>
-        there was atLeastOne(e).identifier
-        repository.resolveBy(e.identifier).isFailure must_== true
-      }.forall
+      forAll(entities) { (e: Entity[Identifier[Int]]) =>
+        verify(e, leastOnce()).identifier
+        repository.resolveBy(e.identifier).isFailure shouldBe true
+      }
       val resultWithEntity2 = resultWithEntity.flatMap {
         _.result.deleteByMulti(entities.map(_.identifier): _*)
       }.get
-      (resultWithEntity2.result ne repository) must beTrue
-      resultWithEntity2.entities must_== entities
+      (resultWithEntity2.result ne repository) shouldBe true
+      resultWithEntity2.entities shouldBe entities
     }
     "fail to resolve a entity by a non-existent identifier" in {
-      val repository = new GenericSyncRepositoryOnMemory[Identifier[Int], EntityImpl]()
-      repository.resolveBy(id).isFailure must_== true
-      repository.resolveBy(id).get must throwA[EntityNotFoundException]
+      val repository =
+        new GenericSyncRepositoryOnMemory[Identifier[Int], EntityImpl]()
+      repository.resolveBy(id).isFailure shouldBe true
+      a[EntityNotFoundException] shouldBe thrownBy(repository.resolveBy(id).get)
     }
     "fail to delete a entity by a non-existent identifier" in {
-      val repository = new GenericSyncRepositoryOnMemory[Identifier[Int], EntityImpl]()
-      repository.deleteBy(id).isFailure must_== true
-      repository.deleteBy(id).get must throwA[EntityNotFoundException]
+      val repository =
+        new GenericSyncRepositoryOnMemory[Identifier[Int], EntityImpl]()
+      repository.deleteBy(id).isFailure shouldBe true
+      a[EntityNotFoundException] shouldBe thrownBy(repository.deleteBy(id).get)
     }
   }
 
   //  "The cloned repository" should {
   //    val repository = new GenericSyncRepositoryOnMemory[Identifier[Int], EntityImpl]()
   //    "equals the repository before clone" in {
-  //      repository must_== repository.clone
+  //      repository shouldBe repository.clone
   //    }
   //    "have unequal values to the repository before clone" in {
   //      val cloneRepository = repository.clone

--- a/scala-dddbase-lifecycle-repositories-memory/jvm/src/test/scala/org/sisioh/dddbase/lifecycle/memory/sync/SyncRepositoryOnMemorySupportAsChunk2Spec.scala
+++ b/scala-dddbase-lifecycle-repositories-memory/jvm/src/test/scala/org/sisioh/dddbase/lifecycle/memory/sync/SyncRepositoryOnMemorySupportAsChunk2Spec.scala
@@ -2,25 +2,28 @@ package org.sisioh.dddbase.lifecycle.memory.sync
 
 import org.sisioh.dddbase.core.lifecycle.sync.SyncEntityIOContext
 import org.sisioh.dddbase.core.model._
-import org.specs2.mock.Mockito
 import org.specs2.mutable.Specification
 
-class SyncRepositoryOnMemorySupportAsChunk2Spec extends Specification with Mockito {
+class SyncRepositoryOnMemorySupportAsChunk2Spec extends Specification {
 
   case class IntIdentifier(value: Int)
-    extends AbstractOrderedIdentifier[Int, IntIdentifier]
+      extends AbstractOrderedIdentifier[Int, IntIdentifier]
 
   class EntityImpl(val identifier: IntIdentifier)
-    extends Entity[IntIdentifier]
-    with EntityCloneable[IntIdentifier, EntityImpl]
-    with EntityOrdered[Int, IntIdentifier, EntityImpl]
+      extends Entity[IntIdentifier]
+      with EntityCloneable[IntIdentifier, EntityImpl]
+      with EntityOrdered[Int, IntIdentifier, EntityImpl]
 
   class TestSyncRepository(entities: Map[IntIdentifier, EntityImpl] = Map.empty)
-      extends AbstractSyncRepositoryOnMemory[IntIdentifier, EntityImpl](entities)
+      extends AbstractSyncRepositoryOnMemory[IntIdentifier, EntityImpl](
+        entities
+      )
       with SyncRepositoryOnMemorySupportAsChunk[IntIdentifier, EntityImpl] {
     type This = TestSyncRepository
 
-    override protected def createInstance(entities: Map[IntIdentifier, EntityImpl]): This =
+    override protected def createInstance(
+      entities: Map[IntIdentifier, EntityImpl]
+    ): This =
       new TestSyncRepository(entities)
   }
 

--- a/scala-dddbase-lifecycle-repositories-memory/jvm/src/test/scala/org/sisioh/dddbase/lifecycle/memory/sync/SyncRepositoryOnMemorySupportAsChunkSpec.scala
+++ b/scala-dddbase-lifecycle-repositories-memory/jvm/src/test/scala/org/sisioh/dddbase/lifecycle/memory/sync/SyncRepositoryOnMemorySupportAsChunkSpec.scala
@@ -2,28 +2,34 @@ package org.sisioh.dddbase.lifecycle.memory.sync
 
 import org.sisioh.dddbase.core.lifecycle.sync.SyncEntityIOContext
 import org.sisioh.dddbase.core.model._
-import org.specs2.mock.Mockito
 import org.specs2.mutable.Specification
 
-class SyncRepositoryOnMemorySupportAsChunkSpec extends Specification with Mockito {
+class SyncRepositoryOnMemorySupportAsChunkSpec extends Specification {
 
   class EntityImpl(val identifier: Identifier[Int])
       extends Entity[Identifier[Int]]
       with EntityCloneable[Identifier[Int], EntityImpl]
       with Ordered[EntityImpl] {
 
-    def compare(that: SyncRepositoryOnMemorySupportAsChunkSpec.this.type#EntityImpl): Int = {
+    def compare(
+      that: SyncRepositoryOnMemorySupportAsChunkSpec.this.type#EntityImpl
+    ): Int = {
       this.identifier.value.compareTo(that.identifier.value)
     }
 
   }
 
-  class TestSyncRepository(entities: Map[Identifier[Int], EntityImpl] = Map.empty)
-      extends AbstractSyncRepositoryOnMemory[Identifier[Int], EntityImpl](entities)
+  class TestSyncRepository(
+    entities: Map[Identifier[Int], EntityImpl] = Map.empty
+  ) extends AbstractSyncRepositoryOnMemory[Identifier[Int], EntityImpl](
+        entities
+      )
       with SyncRepositoryOnMemorySupportAsChunk[Identifier[Int], EntityImpl] {
     type This = TestSyncRepository
 
-    override protected def createInstance(entities: Map[Identifier[Int], EntityImpl]): TestSyncRepository#This =
+    override protected def createInstance(
+      entities: Map[Identifier[Int], EntityImpl]
+    ): TestSyncRepository#This =
       new TestSyncRepository(entities)
   }
 

--- a/scala-dddbase-lifecycle-repositories-memory/jvm/src/test/scala/org/sisioh/dddbase/lifecycle/memory/sync/SyncRepositoryOnMemorySupportByPredicateSpec.scala
+++ b/scala-dddbase-lifecycle-repositories-memory/jvm/src/test/scala/org/sisioh/dddbase/lifecycle/memory/sync/SyncRepositoryOnMemorySupportByPredicateSpec.scala
@@ -2,10 +2,9 @@ package org.sisioh.dddbase.lifecycle.memory.sync
 
 import org.sisioh.dddbase.core.lifecycle.sync.SyncEntityIOContext
 import org.sisioh.dddbase.core.model._
-import org.specs2.mock.Mockito
 import org.specs2.mutable.Specification
 
-class SyncRepositoryOnMemorySupportByPredicateSpec extends Specification with Mockito {
+class SyncRepositoryOnMemorySupportByPredicateSpec extends Specification {
 
   class EntityImpl(val identifier: Identifier[Int])
       extends Entity[Identifier[Int]]
@@ -18,12 +17,17 @@ class SyncRepositoryOnMemorySupportByPredicateSpec extends Specification with Mo
 
   }
 
-  class TestSyncRepository(entities: Map[Identifier[Int], EntityImpl] = Map.empty)
-      extends AbstractSyncRepositoryOnMemory[Identifier[Int], EntityImpl](entities)
+  class TestSyncRepository(
+    entities: Map[Identifier[Int], EntityImpl] = Map.empty
+  ) extends AbstractSyncRepositoryOnMemory[Identifier[Int], EntityImpl](
+        entities
+      )
       with SyncRepositoryOnMemorySupportAsPredicate[Identifier[Int], EntityImpl] {
     type This = TestSyncRepository
 
-    override protected def createInstance(entities: Map[Identifier[Int], EntityImpl]): TestSyncRepository#This =
+    override protected def createInstance(
+      entities: Map[Identifier[Int], EntityImpl]
+    ): TestSyncRepository#This =
       new TestSyncRepository(entities)
   }
 
@@ -39,10 +43,11 @@ class SyncRepositoryOnMemorySupportByPredicateSpec extends Specification with Mo
         repository = repository.store(entity).get.result
       }
 
-      val chunk = repository.filterBy(
-        {
-          e => e.identifier.value % 2 == 0
-        }, Some(0), Some(5)).get
+      val chunk = repository
+        .filterBy({ e =>
+          e.identifier.value % 2 == 0
+        }, Some(0), Some(5))
+        .get
 
       chunk.index must_== 0
       chunk.entities.size must_== 5

--- a/scala-dddbase-lifecycle-repositories-memory/shared/src/main/scala/org/sisioh/dddbase/lifecycle/memory/JDKCollectionConvertersCompat.scala
+++ b/scala-dddbase-lifecycle-repositories-memory/shared/src/main/scala/org/sisioh/dddbase/lifecycle/memory/JDKCollectionConvertersCompat.scala
@@ -1,0 +1,22 @@
+package org.sisioh.dddbase.lifecycle.memory
+
+//FIXME cross-build用オブジェクトの置き場が分からない
+object JDKCollectionConvertersCompat {
+  object Scope1 {
+    object jdk {
+      type CollectionConverters = Int
+    }
+  }
+  import Scope1._
+
+  object Scope2 {
+    import scala.collection.{JavaConverters => CollectionConverters}
+    object Inner {
+      import scala._
+      import jdk.CollectionConverters
+      val Converters = CollectionConverters
+    }
+  }
+
+  val Converters = Scope2.Inner.Converters
+}

--- a/scala-dddbase-lifecycle-repositories-memory/shared/src/main/scala/org/sisioh/dddbase/lifecycle/memory/async/GenericAsyncRepositoryOnMemory.scala
+++ b/scala-dddbase-lifecycle-repositories-memory/shared/src/main/scala/org/sisioh/dddbase/lifecycle/memory/async/GenericAsyncRepositoryOnMemory.scala
@@ -16,20 +16,24 @@
  */
 package org.sisioh.dddbase.lifecycle.memory.async
 
-import org.sisioh.dddbase.core.model.{ Identifier, EntityCloneable, Entity }
+import org.sisioh.dddbase.core.model.{Entity, EntityCloneable, Identifier}
 import org.sisioh.dddbase.lifecycle.forwarding.async.wrapped.AsyncWrappedSyncEntityIOContext
+
 import scala.concurrent.ExecutionContext
-import scala.scalajs.js.annotation.JSExport
+import scala.scalajs.js.annotation.JSExportTopLevel
 
 /**
- * 汎用的な非同期型オンメモリ不変リポジトリ。
- *
- * @param entities マップ
- * @tparam ID 識別子の型
- * @tparam E エンティティの型
- */
-@JSExport
-class GenericAsyncRepositoryOnMemory[ID <: Identifier[_], E <: Entity[ID] with EntityCloneable[ID, E] with Ordered[E]](entities: Map[ID, E] = Map.empty[ID, E])
+  * 汎用的な非同期型オンメモリ不変リポジトリ。
+  *
+  * @param entities マップ
+  * @tparam ID 識別子の型
+  * @tparam E エンティティの型
+  */
+@JSExportTopLevel("AsyncGenericAsyncRepositoryOnMemoryClass")
+class GenericAsyncRepositoryOnMemory[ID <: Identifier[_], E <: Entity[ID] with EntityCloneable[
+  ID,
+  E
+] with Ordered[E]](entities: Map[ID, E] = Map.empty[ID, E])
     extends AbstractAsyncRepositoryOnMemory[ID, E](entities) {
 
   type This = GenericAsyncRepositoryOnMemory[ID, E]
@@ -40,9 +44,9 @@ class GenericAsyncRepositoryOnMemory[ID <: Identifier[_], E <: Entity[ID] with E
 }
 
 /**
- * コンパニオンオブジェクト。
- */
-@JSExport
+  * コンパニオンオブジェクト。
+  */
+@JSExportTopLevel("AsyncGenericAsyncRepositoryOnMemoryObject")
 object GenericAsyncRepositoryOnMemory {
 
   object Implicits {
@@ -54,34 +58,38 @@ object GenericAsyncRepositoryOnMemory {
   }
 
   /**
-   * `org.sisioh.dddbase.core.lifecycle.EntityIOContext`を生成する。
-   *
-   * @param executor `ExecutionContext`
-   * @return `org.sisioh.dddbase.lifecycle.forwarding.async.wrapped.AsyncWrappedSyncEntityIOContext`
-   */
-  def createEntityIOContext(implicit executor: ExecutionContext) = AsyncWrappedSyncEntityIOContext()
+    * `org.sisioh.dddbase.core.lifecycle.EntityIOContext`を生成する。
+    *
+    * @param executor `ExecutionContext`
+    * @return `org.sisioh.dddbase.lifecycle.forwarding.async.wrapped.AsyncWrappedSyncEntityIOContext`
+    */
+  def createEntityIOContext(implicit executor: ExecutionContext) =
+    AsyncWrappedSyncEntityIOContext()
 
   /**
-   * ファクトリメソッド。
-   *
-   * @param entities マップ
-   * @tparam ID 識別子の型
-   * @tparam E エンティティの型
-   * @return `org.sisioh.dddbase.lifecycle.memory.async.GenericAsyncRepositoryOnMemory`
-   */
-  def apply[ID <: Identifier[_], E <: Entity[ID] with EntityCloneable[ID, E] with Ordered[E]](entities: Map[ID, E]) =
+    * ファクトリメソッド。
+    *
+    * @param entities マップ
+    * @tparam ID 識別子の型
+    * @tparam E エンティティの型
+    * @return `org.sisioh.dddbase.lifecycle.memory.async.GenericAsyncRepositoryOnMemory`
+    */
+  def apply[ID <: Identifier[_], E <: Entity[ID] with EntityCloneable[ID, E] with Ordered[
+    E
+  ]](entities: Map[ID, E]) =
     new GenericAsyncRepositoryOnMemory(entities)
 
   /**
-   * エクストラクタメソッド。
-   *
-   * @param repository `org.sisioh.dddbase.lifecycle.memory.async.GenericAsyncRepositoryOnMemory`
-   * @tparam ID 識別子の型
-   * @tparam E エンティティの型
-   * @return 構成要素
-   */
-  def unapply[ID <: Identifier[_], E <: Entity[ID] with EntityCloneable[ID, E] with Ordered[E]](repository: GenericAsyncRepositoryOnMemory[ID, E]): Option[Map[ID, E]] =
+    * エクストラクタメソッド。
+    *
+    * @param repository `org.sisioh.dddbase.lifecycle.memory.async.GenericAsyncRepositoryOnMemory`
+    * @tparam ID 識別子の型
+    * @tparam E エンティティの型
+    * @return 構成要素
+    */
+  def unapply[ID <: Identifier[_], E <: Entity[ID] with EntityCloneable[ID, E] with Ordered[
+    E
+  ]](repository: GenericAsyncRepositoryOnMemory[ID, E]): Option[Map[ID, E]] =
     Some(repository.entities)
 
 }
-

--- a/scala-dddbase-lifecycle-repositories-memory/shared/src/main/scala/org/sisioh/dddbase/lifecycle/memory/mutable/async/AbstractAsyncRepositoryOnMemory.scala
+++ b/scala-dddbase-lifecycle-repositories-memory/shared/src/main/scala/org/sisioh/dddbase/lifecycle/memory/mutable/async/AbstractAsyncRepositoryOnMemory.scala
@@ -15,10 +15,13 @@
  */
 package org.sisioh.dddbase.lifecycle.memory.mutable.async
 
-import org.sisioh.dddbase.core.model.{ EntityCloneable, Entity, Identifier }
+import org.sisioh.dddbase.core.model.{EntityCloneable, Entity, Identifier}
 import java.util.concurrent.ConcurrentHashMap
-import scala.collection.JavaConverters._
+import org.sisioh.dddbase.lifecycle.memory.JDKCollectionConvertersCompat.Converters._
 
-abstract class AbstractAsyncRepositoryOnMemory[ID <: Identifier[_], E <: Entity[ID] with EntityCloneable[ID, E] with Ordered[E]](protected val _entities: collection.concurrent.Map[ID, E] = new ConcurrentHashMap[ID, E]().asScala)
-  extends AsyncRepositoryOnMemorySupport[ID, E]
-
+abstract class AbstractAsyncRepositoryOnMemory[ID <: Identifier[_], E <: Entity[
+  ID
+] with EntityCloneable[ID, E] with Ordered[E]](
+  protected val _entities: collection.concurrent.Map[ID, E] =
+    new ConcurrentHashMap[ID, E]().asScala
+) extends AsyncRepositoryOnMemorySupport[ID, E]

--- a/scala-dddbase-lifecycle-repositories-memory/shared/src/main/scala/org/sisioh/dddbase/lifecycle/memory/mutable/async/GenericAsyncRepositoryOnMemory.scala
+++ b/scala-dddbase-lifecycle-repositories-memory/shared/src/main/scala/org/sisioh/dddbase/lifecycle/memory/mutable/async/GenericAsyncRepositoryOnMemory.scala
@@ -17,30 +17,38 @@
 package org.sisioh.dddbase.lifecycle.memory.mutable.async
 
 import org.sisioh.dddbase.lifecycle.forwarding.async.wrapped.AsyncWrappedSyncEntityIOContext
-import org.sisioh.dddbase.core.model.{ Identifier, EntityCloneable, Entity }
+import org.sisioh.dddbase.core.model.{Entity, EntityCloneable, Identifier}
+
 import scala.concurrent.ExecutionContext
 import java.util.concurrent.ConcurrentHashMap
-import scala.collection.JavaConverters._
-import scala.scalajs.js.annotation.JSExport
+
+import org.sisioh.dddbase.lifecycle.memory.JDKCollectionConvertersCompat.Converters._
+
+import scala.scalajs.js.annotation.JSExportTopLevel
 
 /**
- * 汎用的な非同期型オンメモリ可変リポジトリ。
- *
- * @tparam ID 識別子の型
- * @tparam E エンティティの型
- */
-@JSExport
-class GenericAsyncRepositoryOnMemory[ID <: Identifier[_], E <: Entity[ID] with EntityCloneable[ID, E] with Ordered[E]](entities: collection.concurrent.Map[ID, E] = new ConcurrentHashMap[ID, E]().asScala)
-    extends AbstractAsyncRepositoryOnMemory[ID, E](entities) {
+  * 汎用的な非同期型オンメモリ可変リポジトリ。
+  *
+  * @tparam ID 識別子の型
+  * @tparam E エンティティの型
+  */
+@JSExportTopLevel("MutableAsyncGenericAsyncRepositoryOnMemoryClass")
+class GenericAsyncRepositoryOnMemory[ID <: Identifier[_], E <: Entity[ID] with EntityCloneable[
+  ID,
+  E
+] with Ordered[E]](
+  entities: collection.concurrent.Map[ID, E] =
+    new ConcurrentHashMap[ID, E]().asScala
+) extends AbstractAsyncRepositoryOnMemory[ID, E](entities) {
 
   type This = GenericAsyncRepositoryOnMemory[ID, E]
 
 }
 
 /**
- * コンパニオンオブジェクト。
- */
-@JSExport
+  * コンパニオンオブジェクト。
+  */
+@JSExportTopLevel("MutableAsyncGenericAsyncRepositoryOnMemoryObject")
 object GenericAsyncRepositoryOnMemory {
 
   object Implicits {
@@ -52,34 +60,43 @@ object GenericAsyncRepositoryOnMemory {
   }
 
   /**
-   * `org.sisioh.dddbase.core.lifecycle.EntityIOContext`を生成する。
-   *
-   * @param executor `ExecutionContext`
-   * @return `AsyncWrappedSyncEntityIOContext`
-   */
-  def createEntityIOContext(implicit executor: ExecutionContext) = AsyncWrappedSyncEntityIOContext()
+    * `org.sisioh.dddbase.core.lifecycle.EntityIOContext`を生成する。
+    *
+    * @param executor `ExecutionContext`
+    * @return `AsyncWrappedSyncEntityIOContext`
+    */
+  def createEntityIOContext(implicit executor: ExecutionContext) =
+    AsyncWrappedSyncEntityIOContext()
 
   /**
-   * ファクトリメソッド。
-   *
-   * @param entities マップ
-   * @tparam ID 識別子の型
-   * @tparam E エンティティの型
-   * @return `GenericAsyncRepositoryOnMemory`
-   */
-  def apply[ID <: Identifier[_], E <: Entity[ID] with EntityCloneable[ID, E] with Ordered[E]](entities: collection.concurrent.Map[ID, E] = new ConcurrentHashMap[ID, E]().asScala) =
+    * ファクトリメソッド。
+    *
+    * @param entities マップ
+    * @tparam ID 識別子の型
+    * @tparam E エンティティの型
+    * @return `GenericAsyncRepositoryOnMemory`
+    */
+  def apply[ID <: Identifier[_], E <: Entity[ID] with EntityCloneable[ID, E] with Ordered[
+    E
+  ]](
+    entities: collection.concurrent.Map[ID, E] =
+      new ConcurrentHashMap[ID, E]().asScala
+  ) =
     new GenericAsyncRepositoryOnMemory(entities)
 
   /**
-   * エクストラクタメソッド。
-   *
-   * @param repository `GenericAsyncRepositoryOnMemory`
-   * @tparam ID 識別子の型
-   * @tparam E エンティティの型
-   * @return 構成要素
-   */
-  def unapply[ID <: Identifier[_], E <: Entity[ID] with EntityCloneable[ID, E] with Ordered[E]](repository: GenericAsyncRepositoryOnMemory[ID, E]): Option[(collection.concurrent.Map[ID, E])] =
+    * エクストラクタメソッド。
+    *
+    * @param repository `GenericAsyncRepositoryOnMemory`
+    * @tparam ID 識別子の型
+    * @tparam E エンティティの型
+    * @return 構成要素
+    */
+  def unapply[ID <: Identifier[_], E <: Entity[ID] with EntityCloneable[ID, E] with Ordered[
+    E
+  ]](
+    repository: GenericAsyncRepositoryOnMemory[ID, E]
+  ): Option[(collection.concurrent.Map[ID, E])] =
     Some(repository._entities)
 
 }
-

--- a/scala-dddbase-lifecycle-repositories-memory/shared/src/main/scala/org/sisioh/dddbase/lifecycle/memory/mutable/sync/GenericSyncRepositoryOnMemory.scala
+++ b/scala-dddbase-lifecycle-repositories-memory/shared/src/main/scala/org/sisioh/dddbase/lifecycle/memory/mutable/sync/GenericSyncRepositoryOnMemory.scala
@@ -17,28 +17,32 @@
 package org.sisioh.dddbase.lifecycle.memory.mutable.sync
 
 import org.sisioh.dddbase.core.lifecycle.sync.SyncEntityIOContext
-import org.sisioh.dddbase.core.model.{ Identifier, EntityCloneable, Entity }
+import org.sisioh.dddbase.core.model.{Entity, EntityCloneable, Identifier}
 
-import scala.scalajs.js.annotation.JSExport
+import scala.scalajs.js.annotation.JSExportTopLevel
 
 /**
- * 汎用的な同期型オンメモリ可変リポジトリ。
- *
- * @tparam ID 識別子の型
- * @tparam E エンティティの型
- */
-@JSExport
-class GenericSyncRepositoryOnMemory[ID <: Identifier[_], E <: Entity[ID] with EntityCloneable[ID, E] with Ordered[E]](entities: collection.mutable.Map[ID, E] = collection.mutable.Map.empty[ID, E])
-    extends AbstractSyncRepositoryOnMemory[ID, E](entities) {
+  * 汎用的な同期型オンメモリ可変リポジトリ。
+  *
+  * @tparam ID 識別子の型
+  * @tparam E エンティティの型
+  */
+@JSExportTopLevel("MutableSyncGenericSyncRepositoryOnMemoryClass")
+class GenericSyncRepositoryOnMemory[ID <: Identifier[_], E <: Entity[ID] with EntityCloneable[
+  ID,
+  E
+] with Ordered[E]](
+  entities: collection.mutable.Map[ID, E] = collection.mutable.Map.empty[ID, E]
+) extends AbstractSyncRepositoryOnMemory[ID, E](entities) {
 
   type This = GenericSyncRepositoryOnMemory[ID, E]
 
 }
 
 /**
- * コンパニオンオブジェクト。
- */
-@JSExport
+  * コンパニオンオブジェクト。
+  */
+@JSExportTopLevel("MutableSyncGenericSyncRepositoryOnMemoryObject")
 object GenericSyncRepositoryOnMemory {
 
   object Implicits {
@@ -48,24 +52,33 @@ object GenericSyncRepositoryOnMemory {
   }
 
   /**
-   * ファクトリメソッド。
-   *
-   * @tparam ID 識別子の型
-   * @tparam E エンティティの型
-   * @return `GenericSyncRepositoryOnMemory`
-   */
-  def apply[ID <: Identifier[_], E <: Entity[ID] with EntityCloneable[ID, E] with Ordered[E]](entities: collection.mutable.Map[ID, E] = collection.mutable.Map.empty[ID, E]) =
+    * ファクトリメソッド。
+    *
+    * @tparam ID 識別子の型
+    * @tparam E エンティティの型
+    * @return `GenericSyncRepositoryOnMemory`
+    */
+  def apply[ID <: Identifier[_], E <: Entity[ID] with EntityCloneable[ID, E] with Ordered[
+    E
+  ]](
+    entities: collection.mutable.Map[ID, E] =
+      collection.mutable.Map.empty[ID, E]
+  ) =
     new GenericSyncRepositoryOnMemory[ID, E](entities)
 
   /**
-   * エクストラクタメソッド。
-   *
-   * @param repository `GenericSyncRepositoryOnMemory`
-   * @tparam ID 識別子の型
-   * @tparam E エンティティの型
-   * @return 構成要素
-   */
-  def unapply[ID <: Identifier[_], E <: Entity[ID] with EntityCloneable[ID, E] with Ordered[E]](repository: GenericSyncRepositoryOnMemory[ID, E]): Option[(collection.mutable.Map[ID, E])] =
+    * エクストラクタメソッド。
+    *
+    * @param repository `GenericSyncRepositoryOnMemory`
+    * @tparam ID 識別子の型
+    * @tparam E エンティティの型
+    * @return 構成要素
+    */
+  def unapply[ID <: Identifier[_], E <: Entity[ID] with EntityCloneable[ID, E] with Ordered[
+    E
+  ]](
+    repository: GenericSyncRepositoryOnMemory[ID, E]
+  ): Option[(collection.mutable.Map[ID, E])] =
     Some(repository._entities)
 
 }

--- a/scala-dddbase-lifecycle-repositories-memory/shared/src/main/scala/org/sisioh/dddbase/lifecycle/memory/sync/GenericSyncRepositoryOnMemory.scala
+++ b/scala-dddbase-lifecycle-repositories-memory/shared/src/main/scala/org/sisioh/dddbase/lifecycle/memory/sync/GenericSyncRepositoryOnMemory.scala
@@ -17,30 +17,36 @@
 package org.sisioh.dddbase.lifecycle.memory.sync
 
 import org.sisioh.dddbase.core.lifecycle.sync.SyncEntityIOContext
-import org.sisioh.dddbase.core.model.{ Identifier, EntityCloneable, Entity }
+import org.sisioh.dddbase.core.model.{Entity, EntityCloneable, Identifier}
 
-import scala.scalajs.js.annotation.JSExport
+import scala.scalajs.js.annotation.JSExportTopLevel
 
+//FIXME @JSExportTopLevelのnameを変更する
 /**
- * 汎用的な非同期型オンメモリ不変リポジトリ。
- *
- * @tparam ID 識別子の型
- * @tparam E エンティティの型
- */
-@JSExport
-class GenericSyncRepositoryOnMemory[ID <: Identifier[_], E <: Entity[ID] with EntityCloneable[ID, E] with Ordered[E]](entities: Map[ID, E] = Map.empty[ID, E])
+  * 汎用的な非同期型オンメモリ不変リポジトリ。
+  *
+  * @tparam ID 識別子の型
+  * @tparam E エンティティの型
+  */
+@JSExportTopLevel("SyncGenericSyncRepositoryOnMemoryClass")
+class GenericSyncRepositoryOnMemory[ID <: Identifier[_], E <: Entity[ID] with EntityCloneable[
+  ID,
+  E
+] with Ordered[E]](entities: Map[ID, E] = Map.empty[ID, E])
     extends AbstractSyncRepositoryOnMemory[ID, E](entities) {
 
   type This = GenericSyncRepositoryOnMemory[ID, E]
 
-  override protected def createInstance(entities: Map[ID, E]): GenericSyncRepositoryOnMemory[ID, E]#This =
+  override protected def createInstance(
+    entities: Map[ID, E]
+  ): GenericSyncRepositoryOnMemory[ID, E]#This =
     new GenericSyncRepositoryOnMemory(entities)
 }
 
 /**
- * コンパニオンオブジェクト。
- */
-@JSExport
+  * コンパニオンオブジェクト。
+  */
+@JSExportTopLevel("SyncGenericSyncRepositoryOnMemoryObject")
 object GenericSyncRepositoryOnMemory {
 
   object Implicits {
@@ -50,16 +56,20 @@ object GenericSyncRepositoryOnMemory {
   }
 
   /**
-   * ファクトリメソッド。
-   *
-   * @tparam ID 識別子の型
-   * @tparam E エンティティの型
-   * @return `GenericSyncRepositoryOnMemory`
-   */
-  def apply[ID <: Identifier[_], E <: Entity[ID] with EntityCloneable[ID, E] with Ordered[E]](entities: Map[ID, E] = Map.empty[ID, E]) =
+    * ファクトリメソッド。
+    *
+    * @tparam ID 識別子の型
+    * @tparam E エンティティの型
+    * @return `GenericSyncRepositoryOnMemory`
+    */
+  def apply[ID <: Identifier[_], E <: Entity[ID] with EntityCloneable[ID, E] with Ordered[
+    E
+  ]](entities: Map[ID, E] = Map.empty[ID, E]) =
     new GenericSyncRepositoryOnMemory[ID, E](entities)
 
-  def unapply[ID <: Identifier[_], E <: Entity[ID] with EntityCloneable[ID, E] with Ordered[E]](repository: GenericSyncRepositoryOnMemory[ID, E]): Option[(Map[ID, E])] =
+  def unapply[ID <: Identifier[_], E <: Entity[ID] with EntityCloneable[ID, E] with Ordered[
+    E
+  ]](repository: GenericSyncRepositoryOnMemory[ID, E]): Option[(Map[ID, E])] =
     Some(repository.entities)
 
 }

--- a/scala-dddbase-spec/jvm/src/test/scala/org/sisioh/dddbase/spec/AndSpecificationTest.scala
+++ b/scala-dddbase-spec/jvm/src/test/scala/org/sisioh/dddbase/spec/AndSpecificationTest.scala
@@ -17,20 +17,20 @@
 package org.sisioh.dddbase.spec
 
 import org.junit.Test
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
-import org.scalatest.junit.AssertionsForJUnit
-import org.scalatest.mock.MockitoSugar
+import org.scalatestplus.junit.AssertionsForJUnit
+import org.scalatestplus.mockito.MockitoSugar
 
 class AndSpecificationTest extends AssertionsForJUnit with MockitoSugar {
 
   /**
-   * `false` AND `false` が `false` となること。
-   *
-   * @throws Exception 例外が発生した場合
-   */
+    * `false` AND `false` が `false` となること。
+    *
+    * @throws Exception 例外が発生した場合
+    */
   @Test
-  def est01_false_false_To_false() {
+  def est01_false_false_To_false(): Unit = {
 
     val mock1 = mock[Specification[Unit]]
     val mock2 = mock[Specification[Unit]]
@@ -46,12 +46,12 @@ class AndSpecificationTest extends AssertionsForJUnit with MockitoSugar {
   }
 
   /**
-   * `false` AND `true` が `false` となること。
-   *
-   * @throws Exception 例外が発生した場合
-   */
+    * `false` AND `true` が `false` となること。
+    *
+    * @throws Exception 例外が発生した場合
+    */
   @Test
-  def test02_false_true_To_false() {
+  def test02_false_true_To_false(): Unit = {
 
     val mock1 = mock[Specification[Unit]]
     val mock2 = mock[Specification[Unit]]
@@ -67,12 +67,12 @@ class AndSpecificationTest extends AssertionsForJUnit with MockitoSugar {
   }
 
   /**
-   * `true` AND `false` が `false` となること。
-   *
-   * @throws Exception 例外が発生した場合
-   */
+    * `true` AND `false` が `false` となること。
+    *
+    * @throws Exception 例外が発生した場合
+    */
   @Test
-  def test03_true_false_To_false() {
+  def test03_true_false_To_false(): Unit = {
 
     val mock1 = mock[Specification[Unit]]
     val mock2 = mock[Specification[Unit]]
@@ -88,12 +88,12 @@ class AndSpecificationTest extends AssertionsForJUnit with MockitoSugar {
   }
 
   /**
-   * `true` AND `true` が `true` となること。
-   *
-   * @throws Exception 例外が発生した場合
-   */
+    * `true` AND `true` が `true` となること。
+    *
+    * @throws Exception 例外が発生した場合
+    */
   @Test
-  def test04_true_true_To_true() {
+  def test04_true_true_To_true(): Unit = {
 
     val mock1 = mock[Specification[Unit]]
     val mock2 = mock[Specification[Unit]]

--- a/scala-dddbase-spec/jvm/src/test/scala/org/sisioh/dddbase/spec/NotSpecificationTest.scala
+++ b/scala-dddbase-spec/jvm/src/test/scala/org/sisioh/dddbase/spec/NotSpecificationTest.scala
@@ -17,19 +17,20 @@
 package org.sisioh.dddbase.spec
 
 import org.junit.Test
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
-import org.scalatest.junit.AssertionsForJUnit
-import org.scalatest.mock.MockitoSugar
+import org.scalatestplus.junit.AssertionsForJUnit
+import org.scalatestplus.mockito.MockitoSugar
 
 class NotSpecificationTest extends AssertionsForJUnit with MockitoSugar {
+
   /**
-   * NOT `false` が `true` となること。
-   *
-   * @throws Exception 例外が発生した場合
-   */
+    * NOT `false` が `true` となること。
+    *
+    * @throws Exception 例外が発生した場合
+    */
   @Test
-  def test01_false_To_true() {
+  def test01_false_To_true(): Unit = {
     val mock1 = mock[Specification[Unit]]
 
     when(mock1.isSatisfiedBy(any(classOf[Unit]))).thenReturn(false)
@@ -41,12 +42,12 @@ class NotSpecificationTest extends AssertionsForJUnit with MockitoSugar {
   }
 
   /**
-   * NOT `true` が `false` となること。
-   *
-   * @throws Exception 例外が発生した場合
-   */
+    * NOT `true` が `false` となること。
+    *
+    * @throws Exception 例外が発生した場合
+    */
   @Test
-  def test01_true_To_false() {
+  def test01_true_To_false(): Unit = {
     val mock1 = mock[Specification[Unit]]
 
     when(mock1.isSatisfiedBy(any(classOf[Unit]))).thenReturn(true)

--- a/scala-dddbase-spec/jvm/src/test/scala/org/sisioh/dddbase/spec/OrSpecificationTest.scala
+++ b/scala-dddbase-spec/jvm/src/test/scala/org/sisioh/dddbase/spec/OrSpecificationTest.scala
@@ -17,19 +17,20 @@
 package org.sisioh.dddbase.spec
 
 import org.junit.Test
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
-import org.scalatest.junit.AssertionsForJUnit
-import org.scalatest.mock.MockitoSugar
+import org.scalatestplus.junit.AssertionsForJUnit
+import org.scalatestplus.mockito.MockitoSugar
 
 class OrSpecificationTest extends AssertionsForJUnit with MockitoSugar {
+
   /**
-   * `false` OR `false`が `false`となること。
-   *
-   * @throws Exception 例外が発生した場合
-   */
+    * `false` OR `false`が `false`となること。
+    *
+    * @throws Exception 例外が発生した場合
+    */
   @Test
-  def test01_false_false_To_false() {
+  def test01_false_false_To_false(): Unit = {
     val mock1 = mock[Specification[Unit]]
     val mock2 = mock[Specification[Unit]]
 
@@ -44,12 +45,12 @@ class OrSpecificationTest extends AssertionsForJUnit with MockitoSugar {
   }
 
   /**
-   * `false` OR `true` が `true` となること。
-   *
-   * @throws Exception 例外が発生した場合
-   */
+    * `false` OR `true` が `true` となること。
+    *
+    * @throws Exception 例外が発生した場合
+    */
   @Test
-  def test02_false_true_To_true() {
+  def test02_false_true_To_true(): Unit = {
     val mock1 = mock[Specification[Unit]]
     val mock2 = mock[Specification[Unit]]
 
@@ -64,12 +65,12 @@ class OrSpecificationTest extends AssertionsForJUnit with MockitoSugar {
   }
 
   /**
-   * `true` OR `false`が `true` となること。
-   *
-   * @throws Exception 例外が発生した場合
-   */
+    * `true` OR `false`が `true` となること。
+    *
+    * @throws Exception 例外が発生した場合
+    */
   @Test
-  def test03_true_false_To_true() {
+  def test03_true_false_To_true(): Unit = {
     val mock1 = mock[Specification[Unit]]
     val mock2 = mock[Specification[Unit]]
 
@@ -84,12 +85,12 @@ class OrSpecificationTest extends AssertionsForJUnit with MockitoSugar {
   }
 
   /**
-   * `true` OR `true` が `true` となること。
-   *
-   * @throws Exception 例外が発生した場合
-   */
+    * `true` OR `true` が `true` となること。
+    *
+    * @throws Exception 例外が発生した場合
+    */
   @Test
-  def test04_true_true_To_true() {
+  def test04_true_true_To_true(): Unit = {
     val mock1 = mock[Specification[Unit]]
     val mock2 = mock[Specification[Unit]]
 

--- a/scala-dddbase-spec/jvm/src/test/scala/org/sisioh/dddbase/spec/SpecificationTest.scala
+++ b/scala-dddbase-spec/jvm/src/test/scala/org/sisioh/dddbase/spec/SpecificationTest.scala
@@ -17,21 +17,22 @@
 package org.sisioh.dddbase.spec
 
 import org.junit.Test
-import org.scalatest.junit.AssertionsForJUnit
+import org.scalatestplus.junit.AssertionsForJUnit
 
 /**
- * `org.sisioh.dddbase.spec.Specification`のテストクラス。
- */
+  * `org.sisioh.dddbase.spec.Specification`のテストクラス。
+  */
 class SpecificationTest extends AssertionsForJUnit {
+
   /**
-   * `org.sisioh.dddbase.spec.Specification# a n d ( S p e c i f i c a t i o n )`
-   * `org.sisioh.dddbase.spec.Specification# o r ( S p e c i f i c a t i o n )`
-   * `org.sisioh.dddbase.spec.Specification# n o t`のテスト。
-   *
-   * @throws Exception 例外が発生した場合
-   */
+    * `org.sisioh.dddbase.spec.Specification# a n d ( S p e c i f i c a t i o n )`
+    * `org.sisioh.dddbase.spec.Specification# o r ( S p e c i f i c a t i o n )`
+    * `org.sisioh.dddbase.spec.Specification# n o t`のテスト。
+    *
+    * @throws Exception 例外が発生した場合
+    */
   @Test
-  def test01_and_or_not() {
+  def test01_and_or_not(): Unit = {
     val spec = new Specification[Unit] {
       def isSatisfiedBy(t: Unit): Boolean = false
     }

--- a/scala-dddbase-spec/shared/src/main/scala/org/sisioh/dddbase/spec/AndSpecification.scala
+++ b/scala-dddbase-spec/shared/src/main/scala/org/sisioh/dddbase/spec/AndSpecification.scala
@@ -16,14 +16,14 @@
  */
 package org.sisioh.dddbase.spec
 
-import scala.scalajs.js.annotation.JSExport
+import scala.scalajs.js.annotation.JSExportTopLevel
 
 /**
- * ANDを表す仕様。
- *
- * @tparam T モデルの型
- */
-@JSExport
+  * ANDを表す仕様。
+  *
+  * @tparam T モデルの型
+  */
+@JSExportTopLevel("AndSpecification")
 class AndSpecification[T](private[spec] val spec1: Specification[T],
                           private[spec] val spec2: Specification[T])
     extends Specification[T] {

--- a/scala-dddbase-spec/shared/src/main/scala/org/sisioh/dddbase/spec/NotSpecification.scala
+++ b/scala-dddbase-spec/shared/src/main/scala/org/sisioh/dddbase/spec/NotSpecification.scala
@@ -16,17 +16,17 @@
  */
 package org.sisioh.dddbase.spec
 
-import scala.scalajs.js.annotation.JSExport
+import scala.scalajs.js.annotation.JSExportTopLevel
 
 /**
- * 否定の仕様を表すモデル。
- *
- * <p>ある `Specification` の否定をとる `Specification` 実装クラス。
- * デコレータではないので注意。</p>
- *
- * @tparam T `NotSpecification`の型
- */
-@JSExport
+  * 否定の仕様を表すモデル。
+  *
+  * <p>ある `Specification` の否定をとる `Specification` 実装クラス。
+  * デコレータではないので注意。</p>
+  *
+  * @tparam T `NotSpecification`の型
+  */
+@JSExportTopLevel("NotSpecification")
 class NotSpecification[T](private[spec] val spec1: Specification[T])
     extends Specification[T] {
 

--- a/scala-dddbase-spec/shared/src/main/scala/org/sisioh/dddbase/spec/OrSpecification.scala
+++ b/scala-dddbase-spec/shared/src/main/scala/org/sisioh/dddbase/spec/OrSpecification.scala
@@ -16,16 +16,17 @@
  */
 package org.sisioh.dddbase.spec
 
-import scala.scalajs.js.annotation.JSExport
+import scala.scalajs.js.annotation.JSExportTopLevel
 
 /**
- * 論理和の仕様を表すモデル。
- *
- * <p>2つの `Specification` の論理和をとる `Specification` 実装クラス。</p>
- *
- * @tparam T `OrSpecification`の型
- */
-@JSExport
+  * 論理和の仕様を表すモデル。
+  *
+  * <p>2つの `Specification` の論理和をとる `Specification` 実装クラス。</p>
+  *
+  * @tparam T `OrSpecification`の型
+  */
+
+@JSExportTopLevel("OrSpecification")
 class OrSpecification[T](private[spec] val spec1: Specification[T],
                          private[spec] val spec2: Specification[T])
     extends Specification[T] {


### PR DESCRIPTION
#33 Update Scala2.13
ScalaのVersionを2.13へ更新しました。
sbtのVersionを1.3.4へ更新しました。
合わせて依存しているライブラリのバージョンを更新しています。
crossScalaVersionから2.10.5を削除しました。


- FIXME: verificationModeのatLeastOnceが競合するため、名称を変更
org.mockito.Mockito.atLeastOnceがorg.specs2.matcher.Macthers.atLeastOnceと競合したので名称を変更しています。

- TODO: これより下で使われるforAllの変更箇所が元と同じ意味なのか要確認
Specs2のバージョンを引き上げた際、specs2.mock以下のディレクトリが消えていたので、それに合わせてテストを変更しています。

- FIXME: "error" Duplicate test name
GenericAsyncRepositoryOnMemorySpecのテストを書き換えた際にspecs2とscalatestが競合してしまったため、SpecificationからAnyFreeSpecに変更しています。

- FIXME @JSExportTopLevelのnameを変更する
@JSExport on classes is deprecated and will be removed in 1.0.0. Use @JSExportTopLevel instead (which does exactly the same thing on classes).
JSExportを@JSExportTopLevelに差し替えましたが、@JSExportTopLevel(name: String)のnameをclass名やobjext名と同じにした場合、test時に下記エラーが発生
```
[error] Conflicting top-level exports to GenericSyncRepositoryOnMemory from the following classes:
[error] - org.sisioh.dddbase.lifecycle.memory.mutable.sync.GenericSyncRepositoryOnMemory
[error] - org.sisioh.dddbase.lifecycle.memory.sync.GenericSyncRepositoryOnMemory$
[error] - org.sisioh.dddbase.lifecycle.memory.sync.GenericSyncRepositoryOnMemory
[error] - org.sisioh.dddbase.lifecycle.memory.mutable.sync.GenericSyncRepositoryOnMemory$
[error] Conflicting top-level exports to GenericAsyncRepositoryOnMemory from the following classes:
[error] - org.sisioh.dddbase.lifecycle.memory.async.GenericAsyncRepositoryOnMemory
[error] - org.sisioh.dddbase.lifecycle.memory.mutable.async.GenericAsyncRepositoryOnMemory
[error] - org.sisioh.dddbase.lifecycle.memory.async.GenericAsyncRepositoryOnMemory$
[error] - org.sisioh.dddbase.lifecycle.memory.mutable.async.GenericAsyncRepositoryOnMemory$
```
　nameが重ならないように修正しました。

- FIXME cross-build用オブジェクトの置き場が分からない
クロスビルド用のオブジェクトをどこに配置すればいいか分からなかったので、修正お願いします。
オブジェクト: JDKCollectionConvertersCompat